### PR TITLE
Reduce memory and CPU use

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -44,4 +44,4 @@ require (
 	honnef.co/go/js/dom v0.0.0-20210725211120-f030747120f2 // indirect
 )
 
-replace fyne.io/fyne/v2 v2.2.4 => github.com/dweymouth/fyne/v2 v2.2.5-0.20221227225053-ae75dfbeb567
+replace fyne.io/fyne/v2 v2.2.4 => github.com/dweymouth/fyne/v2 v2.2.5-0.20230110012952-10b53c64afce

--- a/go.mod
+++ b/go.mod
@@ -44,4 +44,4 @@ require (
 	honnef.co/go/js/dom v0.0.0-20210725211120-f030747120f2 // indirect
 )
 
-replace fyne.io/fyne/v2 v2.2.4 => github.com/dweymouth/fyne/v2 v2.2.5-0.20230110012952-10b53c64afce
+replace fyne.io/fyne/v2 v2.2.4 => github.com/dweymouth/fyne/v2 v2.2.5-0.20230110171955-98071d7f072f

--- a/go.sum
+++ b/go.sum
@@ -72,8 +72,8 @@ github.com/danieljoos/wincred v1.1.0/go.mod h1:XYlo+eRTsVA9aHGp7NGjFkPla4m+DCL7h
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dweymouth/fyne/v2 v2.2.5-0.20221227225053-ae75dfbeb567 h1:JEBJ5YN74ryKQNW1TgH0GjHkVpgmHMb1oYuz8ZShjY8=
-github.com/dweymouth/fyne/v2 v2.2.5-0.20221227225053-ae75dfbeb567/go.mod h1:MBoGuHzLLSXdQOWFAwWhIhYTEMp33zqtGCReSWhaQTA=
+github.com/dweymouth/fyne/v2 v2.2.5-0.20230110012952-10b53c64afce h1:hoKExh5/o+OEO0Aq2IE3pwL8qSfRk/6JE/Y+82BKvuE=
+github.com/dweymouth/fyne/v2 v2.2.5-0.20230110012952-10b53c64afce/go.mod h1:MBoGuHzLLSXdQOWFAwWhIhYTEMp33zqtGCReSWhaQTA=
 github.com/dweymouth/go-subsonic v0.0.0-20221214005741-bd8048fa1863 h1:bOWMpFJ9zY839T1EngQ5nxVCiMlatPtpGkg/yHK6szg=
 github.com/dweymouth/go-subsonic v0.0.0-20221214005741-bd8048fa1863/go.mod h1:fUez6NFiEJiQTZizZ1BThZr5GJXAbigzGYjEPNm4tdI=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=

--- a/go.sum
+++ b/go.sum
@@ -72,8 +72,8 @@ github.com/danieljoos/wincred v1.1.0/go.mod h1:XYlo+eRTsVA9aHGp7NGjFkPla4m+DCL7h
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dweymouth/fyne/v2 v2.2.5-0.20230110012952-10b53c64afce h1:hoKExh5/o+OEO0Aq2IE3pwL8qSfRk/6JE/Y+82BKvuE=
-github.com/dweymouth/fyne/v2 v2.2.5-0.20230110012952-10b53c64afce/go.mod h1:MBoGuHzLLSXdQOWFAwWhIhYTEMp33zqtGCReSWhaQTA=
+github.com/dweymouth/fyne/v2 v2.2.5-0.20230110171955-98071d7f072f h1:Tgz5Tx14yQLkKl4JH5eGWnUpq9J8+cbLTuj8lfzgqG0=
+github.com/dweymouth/fyne/v2 v2.2.5-0.20230110171955-98071d7f072f/go.mod h1:MBoGuHzLLSXdQOWFAwWhIhYTEMp33zqtGCReSWhaQTA=
 github.com/dweymouth/go-subsonic v0.0.0-20221214005741-bd8048fa1863 h1:bOWMpFJ9zY839T1EngQ5nxVCiMlatPtpGkg/yHK6szg=
 github.com/dweymouth/go-subsonic v0.0.0-20221214005741-bd8048fa1863/go.mod h1:fUez6NFiEJiQTZizZ1BThZr5GJXAbigzGYjEPNm4tdI=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=

--- a/ui/browsing/albumpage.go
+++ b/ui/browsing/albumpage.go
@@ -52,6 +52,15 @@ func (a *AlbumPage) SetPlayAlbumCallback(cb func(string, int)) {
 	a.OnPlayAlbum = cb
 }
 
+func (a *AlbumPage) Save() SavedPage {
+	return &savedAlbumPage{
+		albumID: a.albumID,
+		lm:      a.lm,
+		im:      a.im,
+		nav:     a.nav,
+	}
+}
+
 func (a *AlbumPage) Route() Route {
 	return AlbumRoute(a.albumID)
 }
@@ -174,4 +183,15 @@ func (a *AlbumPageHeader) Update(album *subsonic.AlbumID3, im *backend.ImageMana
 
 func formatMiscLabelStr(a *subsonic.AlbumID3) string {
 	return fmt.Sprintf("%d · %d tracks · %s", a.Year, a.SongCount, util.SecondsToTimeString(float64(a.Duration)))
+}
+
+type savedAlbumPage struct {
+	albumID string
+	lm      *backend.LibraryManager
+	im      *backend.ImageManager
+	nav     func(Route)
+}
+
+func (s *savedAlbumPage) Restore() Page {
+	return NewAlbumPage(s.albumID, s.lm, s.im, s.nav)
 }

--- a/ui/browsing/artistpage.go
+++ b/ui/browsing/artistpage.go
@@ -57,6 +57,15 @@ func (a *ArtistPage) Reload() {
 	a.loadAsync()
 }
 
+func (a *ArtistPage) Save() SavedPage {
+	return &savedArtistPage{
+		artistID: a.artistID,
+		sm:       a.sm,
+		im:       a.im,
+		nav:      a.nav,
+	}
+}
+
 func (a *ArtistPage) onPlayAlbum(albumID string) {
 	if a.OnPlayAlbum != nil {
 		a.OnPlayAlbum(albumID, 0)
@@ -87,4 +96,15 @@ func (a *ArtistPage) loadAsync() {
 func (a *ArtistPage) CreateRenderer() fyne.WidgetRenderer {
 	a.ExtendBaseWidget(a)
 	return widget.NewSimpleRenderer(a.container)
+}
+
+type savedArtistPage struct {
+	artistID string
+	sm       *backend.ServerManager
+	im       *backend.ImageManager
+	nav      func(Route)
+}
+
+func (s *savedArtistPage) Restore() Page {
+	return NewArtistPage(s.artistID, s.sm, s.im, s.nav)
 }

--- a/ui/browsing/browsingpane.go
+++ b/ui/browsing/browsingpane.go
@@ -2,7 +2,6 @@ package browsing
 
 import (
 	"image/color"
-	"log"
 	"supersonic/backend"
 
 	"fyne.io/fyne/v2"
@@ -129,7 +128,6 @@ func (b *BrowsingPane) goHome() {
 }
 
 func (b *BrowsingPane) GoBack() {
-	log.Printf("goBack called! historyIdx=%d, len=%d", b.historyIdx, len(b.history))
 	if b.historyIdx > 0 {
 		b.addPageToHistory(b.curPage, false)
 		b.historyIdx -= 2
@@ -138,7 +136,6 @@ func (b *BrowsingPane) GoBack() {
 }
 
 func (b *BrowsingPane) GoForward() {
-	log.Printf("goForward called! historyIdx=%d, len=%d", b.historyIdx, len(b.history))
 	if b.historyIdx < len(b.history)-1 {
 		b.addPageToHistory(b.curPage, false)
 		b.doSetPage(b.history[b.historyIdx].Restore())

--- a/ui/browsing/browsingpane.go
+++ b/ui/browsing/browsingpane.go
@@ -2,6 +2,7 @@ package browsing
 
 import (
 	"image/color"
+	"log"
 	"supersonic/backend"
 
 	"fyne.io/fyne/v2"
@@ -16,8 +17,13 @@ import (
 type Page interface {
 	fyne.CanvasObject
 
+	Save() SavedPage
 	Reload()
 	Route() Route
+}
+
+type SavedPage interface {
+	Restore() Page
 }
 
 type CanPlayAlbum interface {
@@ -42,7 +48,7 @@ type BrowsingPane struct {
 	forward    *widget.Button
 	back       *widget.Button
 	reload     *widget.Button
-	history    []Page
+	history    []SavedPage
 	historyIdx int
 
 	pageContainer *fyne.Container
@@ -67,8 +73,9 @@ func NewBrowsingPane(app *backend.App) *BrowsingPane {
 }
 
 func (b *BrowsingPane) SetPage(p Page) {
-	if b.doSetPage(p) {
-		b.addPageToHistory(p)
+	oldPage := b.curPage
+	if b.doSetPage(p) && oldPage != nil {
+		b.addPageToHistory(oldPage, true)
 	}
 }
 
@@ -99,13 +106,19 @@ func (b *BrowsingPane) onSongChange(song *subsonic.Child) {
 	}
 }
 
-func (b *BrowsingPane) addPageToHistory(p Page) {
-	// allow garbage collection of pages that will be removed from the history
-	for i := b.historyIdx; i < len(b.history); i++ {
-		b.history[i] = nil
+func (b *BrowsingPane) addPageToHistory(p Page, truncate bool) {
+	if truncate {
+		// allow garbage collection of pages that will be removed from the history
+		for i := b.historyIdx; i < len(b.history); i++ {
+			b.history[i] = nil
+		}
+		b.history = b.history[:b.historyIdx]
 	}
-	b.history = b.history[:b.historyIdx]
-	b.history = append(b.history, p)
+	if b.historyIdx < len(b.history) {
+		b.history[b.historyIdx] = p.Save()
+	} else {
+		b.history = append(b.history, p.Save())
+	}
 	b.historyIdx++
 }
 
@@ -116,16 +129,19 @@ func (b *BrowsingPane) goHome() {
 }
 
 func (b *BrowsingPane) GoBack() {
-	if b.historyIdx > 1 {
-		b.historyIdx -= 1
-		b.doSetPage(b.history[b.historyIdx-1])
+	log.Printf("goBack called! historyIdx=%d, len=%d", b.historyIdx, len(b.history))
+	if b.historyIdx > 0 {
+		b.addPageToHistory(b.curPage, false)
+		b.historyIdx -= 2
+		b.doSetPage(b.history[b.historyIdx].Restore())
 	}
 }
 
 func (b *BrowsingPane) GoForward() {
-	if b.historyIdx < len(b.history) {
-		b.historyIdx++
-		b.doSetPage(b.history[b.historyIdx-1])
+	log.Printf("goForward called! historyIdx=%d, len=%d", b.historyIdx, len(b.history))
+	if b.historyIdx < len(b.history)-1 {
+		b.addPageToHistory(b.curPage, false)
+		b.doSetPage(b.history[b.historyIdx].Restore())
 	}
 }
 

--- a/ui/browsing/browsingpane.go
+++ b/ui/browsing/browsingpane.go
@@ -100,6 +100,10 @@ func (b *BrowsingPane) onSongChange(song *subsonic.Child) {
 }
 
 func (b *BrowsingPane) addPageToHistory(p Page) {
+	// allow garbage collection of pages that will be removed from the history
+	for i := b.historyIdx; i < len(b.history); i++ {
+		b.history[i] = nil
+	}
 	b.history = b.history[:b.historyIdx]
 	b.history = append(b.history, p)
 	b.historyIdx++

--- a/ui/widgets/albumgrid.go
+++ b/ui/widgets/albumgrid.go
@@ -81,11 +81,10 @@ func (ag *AlbumGrid) SaveToState() AlbumGridState {
 }
 
 func NewAlbumGridFromState(state AlbumGridState) *AlbumGrid {
-	log.Printf("restoring album grid from state: %+v", state)
 	ag := &AlbumGrid{AlbumGridState: state}
 	ag.ExtendBaseWidget(ag)
 	ag.createGridWrapList()
-	ag.Refresh()
+	ag.Refresh() // needed to initialize the widget
 	ag.grid.ScrollToOffset(state.scrollPos)
 	return ag
 }

--- a/ui/widgets/albumgrid.go
+++ b/ui/widgets/albumgrid.go
@@ -22,7 +22,12 @@ type AlbumIterator interface {
 type AlbumGrid struct {
 	widget.BaseWidget
 
-	grid     *widget.GridWrapList
+	AlbumGridState
+
+	grid *widget.GridWrapList
+}
+
+type AlbumGridState struct {
 	albums   []*subsonic.AlbumID3
 	iter     AlbumIterator
 	fetching bool
@@ -33,16 +38,20 @@ type AlbumGrid struct {
 	OnPlayAlbum      func(string)
 	OnShowAlbumPage  func(string)
 	OnShowArtistPage func(string)
+
+	scrollPos float32
 }
 
 var _ fyne.Widget = (*AlbumGrid)(nil)
 
 func NewFixedAlbumGrid(albums []*subsonic.AlbumID3, fetch ImageFetcher, showYear bool) *AlbumGrid {
 	ag := &AlbumGrid{
-		albums:       albums,
-		done:         true,
-		imageFetcher: fetch,
-		showYear:     showYear,
+		AlbumGridState: AlbumGridState{
+			albums:       albums,
+			done:         true,
+			imageFetcher: fetch,
+			showYear:     showYear,
+		},
 	}
 	ag.ExtendBaseWidget(ag)
 	ag.createGridWrapList()
@@ -51,8 +60,10 @@ func NewFixedAlbumGrid(albums []*subsonic.AlbumID3, fetch ImageFetcher, showYear
 
 func NewAlbumGrid(iter AlbumIterator, fetch ImageFetcher, showYear bool) *AlbumGrid {
 	ag := &AlbumGrid{
-		iter:         iter,
-		imageFetcher: fetch,
+		AlbumGridState: AlbumGridState{
+			iter:         iter,
+			imageFetcher: fetch,
+		},
 	}
 	ag.ExtendBaseWidget(ag)
 
@@ -60,6 +71,22 @@ func NewAlbumGrid(iter AlbumIterator, fetch ImageFetcher, showYear bool) *AlbumG
 
 	// fetch initial albums
 	ag.fetchMoreAlbums(36)
+	return ag
+}
+
+func (ag *AlbumGrid) SaveToState() AlbumGridState {
+	s := ag.AlbumGridState
+	s.scrollPos = ag.grid.GetScrollOffset()
+	return s
+}
+
+func NewAlbumGridFromState(state AlbumGridState) *AlbumGrid {
+	log.Printf("restoring album grid from state: %+v", state)
+	ag := &AlbumGrid{AlbumGridState: state}
+	ag.ExtendBaseWidget(ag)
+	ag.createGridWrapList()
+	ag.Refresh()
+	ag.grid.ScrollToOffset(state.scrollPos)
 	return ag
 }
 


### PR DESCRIPTION
- Store only the backing model and state for pages in the history; reconstruct the UI elements when they're navigated to
- Updated custom Fyne fork to poll GLFW events at 10fps vs 60