### PR TITLE
Feature/favorite artists songs

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Slightly outdated screenshots of Supersonic running against the Navidrome <a hre
 * [x] Artist view with biography, image, similar artists, and discography
 * [x] Create, play, and update playlists
 * [x] Configure visible tracklist columns
-* [x] Set/unset favorite and browse by favorites (albums only; artists+songs coming soon)
+* [x] Set/unset favorite and browse by favorite albums, artists, and songs
 * [x] View and edit play queue (add and remove tracks; reorder support coming soon)
 * [ ] Shuffle and repeat playback modes (planned)
 * [ ] Set and view five-star rating (planned)

--- a/backend/config.go
+++ b/backend/config.go
@@ -24,6 +24,11 @@ type AlbumPageConfig struct {
 	TracklistColumns []string
 }
 
+type FavoritesPageConfig struct {
+	InitialView      string
+	TracklistColumns []string
+}
+
 type NowPlayingPageConfig struct {
 	TracklistColumns []string
 }
@@ -40,6 +45,7 @@ type Config struct {
 	Application    AppConfig
 	Servers        []*ServerConfig
 	AlbumPage      AlbumPageConfig
+	FavoritesPage  FavoritesPageConfig
 	NowPlayingPage NowPlayingPageConfig
 	PlaylistPage   PlaylistPageConfig
 	LocalPlayback  LocalPlaybackConfig
@@ -52,10 +58,14 @@ func DefaultConfig() *Config {
 			WindowHeight: 800,
 		},
 		AlbumPage: AlbumPageConfig{
-			TracklistColumns: []string{"Artist", "Time", "Plays"},
+			TracklistColumns: []string{"Artist", "Time", "Plays", "Favorite"},
+		},
+		FavoritesPage: FavoritesPageConfig{
+			TracklistColumns: []string{"Artist", "Album", "Time", "Plays"},
+			InitialView:      "Albums",
 		},
 		NowPlayingPage: NowPlayingPageConfig{
-			TracklistColumns: []string{"Artist", "Album", "Time"},
+			TracklistColumns: []string{"Artist", "Album", "Time", "Plays"},
 		},
 		PlaylistPage: PlaylistPageConfig{
 			TracklistColumns: []string{"Artist", "Album", "Time", "Plays"},

--- a/backend/playbackmanager.go
+++ b/backend/playbackmanager.go
@@ -191,11 +191,12 @@ func (p *PlaybackManager) GetPlayQueue() []*subsonic.Child {
 // Any time the user changes the favorite status of a track elsewhere in the app,
 // this should be called to ensure the in-memory track model is updated.
 func (p *PlaybackManager) OnTrackFavoriteStatusChanged(id string, fav bool) {
-	tr := sharedutil.FindTrackByID(id, p.playQueue)
-	if fav {
-		tr.Starred = time.Now()
-	} else {
-		tr.Starred = time.Time{}
+	if tr := sharedutil.FindTrackByID(id, p.playQueue); tr != nil {
+		if fav {
+			tr.Starred = time.Now()
+		} else {
+			tr.Starred = time.Time{}
+		}
 	}
 }
 

--- a/sharedutil/sharedutil.go
+++ b/sharedutil/sharedutil.go
@@ -1,0 +1,19 @@
+package sharedutil
+
+import "github.com/dweymouth/go-subsonic/subsonic"
+
+func FindTrackByID(id string, tracks []*subsonic.Child) *subsonic.Child {
+	for _, tr := range tracks {
+		if id == tr.ID {
+			return tr
+		}
+	}
+	return nil
+}
+
+func TrackIDOrEmptyStr(track *subsonic.Child) string {
+	if track == nil {
+		return ""
+	}
+	return track.ID
+}

--- a/ui/browsing/albumpage.go
+++ b/ui/browsing/albumpage.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"supersonic/backend"
 	"supersonic/res"
+	"supersonic/sharedutil"
 	"supersonic/ui/controller"
 	"supersonic/ui/layouts"
 	"supersonic/ui/util"
@@ -100,7 +101,7 @@ func (a *AlbumPage) OnSongChange(song *subsonic.Child, lastScrobbledIfAny *subso
 		a.nowPlayingID = song.ID
 	}
 	a.tracklist.SetNowPlaying(a.nowPlayingID)
-	a.tracklist.IncrementPlayCount(lastScrobbledIfAny)
+	a.tracklist.IncrementPlayCount(sharedutil.TrackIDOrEmptyStr(lastScrobbledIfAny))
 }
 
 func (a *AlbumPage) Reload() {

--- a/ui/browsing/albumpage.go
+++ b/ui/browsing/albumpage.go
@@ -66,14 +66,7 @@ func NewAlbumPage(
 	a.header = NewAlbumPageHeader(a)
 	a.tracklist = widgets.NewTracklist(nil)
 	a.tracklist.SetVisibleColumns(a.cfg.TracklistColumns)
-	// connect tracklist actions
-	a.tracklist.OnPlayTrackAt = a.onPlayTrackAt
-	a.tracklist.OnAddToQueue = func(tracks []*subsonic.Child) { a.pm.LoadTracks(tracks, true, false) }
-	a.tracklist.OnPlaySelection = func(tracks []*subsonic.Child) {
-		a.pm.LoadTracks(tracks, false, false)
-		a.pm.PlayFromBeginning()
-	}
-	a.tracklist.OnAddToPlaylist = a.contr.DoAddTracksToPlaylistWorkflow
+	a.contr.ConnectTracklistActions(a.tracklist)
 
 	a.container = container.NewBorder(
 		container.New(&layouts.MaxPadLayout{PadLeft: 15, PadRight: 15, PadTop: 15, PadBottom: 10}, a.header),
@@ -120,11 +113,6 @@ func (a *AlbumPage) Tapped(*fyne.PointEvent) {
 
 func (a *AlbumPage) SelectAll() {
 	a.tracklist.SelectAll()
-}
-
-func (a *AlbumPage) onPlayTrackAt(tracknum int) {
-	a.pm.LoadTracks(a.tracklist.Tracks, false, false)
-	a.pm.PlayTrackAt(tracknum)
 }
 
 // should be called asynchronously
@@ -185,7 +173,7 @@ func NewAlbumPageHeader(page *AlbumPage) *AlbumPageHeader {
 	}
 	a.miscLabel = widget.NewLabel("")
 	playButton := widget.NewButtonWithIcon("Play", theme.MediaPlayIcon(), func() {
-		page.onPlayTrackAt(0)
+		go page.pm.PlayAlbum(page.albumID, 0)
 	})
 	shuffleBtn := widget.NewButtonWithIcon(" Shuffle", res.ResShuffleInvertSvg, func() {
 		page.pm.LoadTracks(page.tracklist.Tracks, false, true)

--- a/ui/browsing/favoritespage.go
+++ b/ui/browsing/favoritespage.go
@@ -27,8 +27,9 @@ type FavoritesPage struct {
 	lm    *backend.LibraryManager
 	nav   func(Route)
 
-	searchText   string
-	nowPlayingID string
+	searchText        string
+	nowPlayingID      string
+	pendingViewSwitch bool
 
 	grid          *widgets.AlbumGrid
 	searchGrid    *widgets.AlbumGrid
@@ -205,10 +206,14 @@ func (a *FavoritesPage) onShowFavoriteAlbums() {
 func (a *FavoritesPage) onShowFavoriteArtists() {
 	a.searcher.Entry.Hide() // disable search on artists for now
 	if a.artistListCtr == nil {
+		if a.pendingViewSwitch {
+			return
+		}
+		a.pendingViewSwitch = true
 		go func() {
 			s, err := a.sm.Server.GetStarred2(nil)
 			if err != nil {
-				log.Println("error getting starred items: %s", err.Error())
+				log.Printf("error getting starred items: %s", err.Error())
 				return
 			}
 			model := make([]widgets.ArtistGenrePlaylistItemModel, 0)
@@ -228,6 +233,7 @@ func (a *FavoritesPage) onShowFavoriteArtists() {
 				artistList)
 			a.container.Objects[0] = a.artistListCtr
 			a.Refresh()
+			a.pendingViewSwitch = false
 		}()
 	} else {
 		a.container.Objects[0] = a.artistListCtr
@@ -238,6 +244,10 @@ func (a *FavoritesPage) onShowFavoriteArtists() {
 func (a *FavoritesPage) onShowFavoriteSongs() {
 	a.searcher.Entry.Hide() // disable search on songs for now
 	if a.tracklistCtr == nil {
+		if a.pendingViewSwitch {
+			return
+		}
+		a.pendingViewSwitch = true
 		go func() {
 			s, err := a.sm.Server.GetStarred2(nil)
 			if err != nil {
@@ -255,6 +265,7 @@ func (a *FavoritesPage) onShowFavoriteSongs() {
 				tracklist)
 			a.container.Objects[0] = a.tracklistCtr
 			a.Refresh()
+			a.pendingViewSwitch = false
 		}()
 	} else {
 		a.container.Objects[0] = a.tracklistCtr

--- a/ui/browsing/favoritespage.go
+++ b/ui/browsing/favoritespage.go
@@ -41,27 +41,18 @@ func NewFavoritesPage(sm *backend.ServerManager, pm *backend.PlaybackManager, lm
 		nav: nav,
 	}
 	a.ExtendBaseWidget(a)
-	a.createTitle()
-	iter := lm.StarredIter()
-	a.grid = widgets.NewAlbumGrid(iter, im, false)
-	a.grid.OnPlayAlbum = a.onPlayAlbum
-	a.grid.OnShowAlbumPage = a.onShowAlbumPage
-	a.grid.OnShowArtistPage = a.onShowArtistPage
-	a.searcher = widgets.NewSearcher()
-	a.searcher.OnSearched = a.OnSearched
-	a.createToggleButtons(0)
+	a.createHeader(0, "")
+	a.grid = widgets.NewAlbumGrid(a.lm.StarredIter(), a.im, false)
+	a.connectGridActions()
 	a.createContainer(false)
 	return a
 }
 
-func (a *FavoritesPage) createTitle() {
+func (a *FavoritesPage) createHeader(activeBtnIdx int, searchText string) {
 	a.titleDisp = widget.NewRichTextWithText("Favorites")
 	a.titleDisp.Segments[0].(*widget.TextSegment).Style = widget.RichTextStyle{
 		SizeName: theme.SizeNameHeadingText,
 	}
-}
-
-func (a *FavoritesPage) createToggleButtons(activeBtnIdx int) {
 	a.toggleBtns = widgets.NewToggleButtonGroup(activeBtnIdx,
 		widget.NewButtonWithIcon("", res.ResDiscInvertPng, func() {
 			log.Println("albums activated")
@@ -72,6 +63,15 @@ func (a *FavoritesPage) createToggleButtons(activeBtnIdx int) {
 		widget.NewButtonWithIcon("", res.ResMusicnotesInvertPng, func() {
 			log.Println("songs activated")
 		}))
+	a.searcher = widgets.NewSearcher()
+	a.searcher.OnSearched = a.OnSearched
+	a.searcher.Entry.Text = searchText
+}
+
+func (a *FavoritesPage) connectGridActions() {
+	a.grid.OnPlayAlbum = a.onPlayAlbum
+	a.grid.OnShowAlbumPage = a.onShowAlbumPage
+	a.grid.OnShowArtistPage = a.onShowArtistPage
 }
 
 func (a *FavoritesPage) createContainer(searchGrid bool) {
@@ -94,18 +94,13 @@ func restoreFavoritesPage(saved *savedFavoritesPage) *FavoritesPage {
 		nav: saved.nav,
 	}
 	a.ExtendBaseWidget(a)
-	a.createTitle()
+	a.createHeader(saved.activeToggleBtn, saved.searchText)
 	a.grid = widgets.NewAlbumGridFromState(saved.gridState)
-	a.grid.OnPlayAlbum = a.onPlayAlbum
-	a.grid.OnShowAlbumPage = a.onShowAlbumPage
-	a.grid.OnShowArtistPage = a.onShowArtistPage
-	a.searcher = widgets.NewSearcher()
-	a.searcher.OnSearched = a.OnSearched
-	a.searcher.Entry.Text = saved.searchText
+	a.connectGridActions()
+
 	if saved.searchText != "" {
 		a.searchGrid = widgets.NewAlbumGridFromState(saved.searchGridState)
 	}
-	a.createToggleButtons(saved.activeToggleBtn)
 	a.createContainer(saved.searchText != "")
 
 	return a

--- a/ui/browsing/favoritespage.go
+++ b/ui/browsing/favoritespage.go
@@ -226,23 +226,13 @@ func (a *FavoritesPage) onShowFavoriteSongs() {
 		go func() {
 			s, err := a.sm.Server.GetStarred2(nil)
 			if err != nil {
-				log.Println("error getting starred items: %s", err.Error())
+				log.Printf("error getting starred items: %s", err.Error())
 				return
 			}
 			tracklist := widgets.NewTracklist(s.Song)
 			// TODO: get visible columns from config
 			tracklist.SetVisibleColumns([]string{"Artist", "Album", "Plays"})
-			// connect tracklist actions
-			tracklist.OnPlayTrackAt = func(idx int) {
-				a.pm.LoadTracks(tracklist.Tracks, false, false)
-				a.pm.PlayTrackAt(idx)
-			}
-			tracklist.OnAddToQueue = func(tracks []*subsonic.Child) { a.pm.LoadTracks(tracks, true, false) }
-			tracklist.OnPlaySelection = func(tracks []*subsonic.Child) {
-				a.pm.LoadTracks(tracks, false, false)
-				a.pm.PlayFromBeginning()
-			}
-			tracklist.OnAddToPlaylist = a.contr.DoAddTracksToPlaylistWorkflow
+			a.contr.ConnectTracklistActions(tracklist)
 			a.tracklistCtr = container.New(
 				&layouts.MaxPadLayout{PadLeft: 15, PadRight: 15, PadTop: 5, PadBottom: 15},
 				tracklist)

--- a/ui/browsing/nowplayingpage.go
+++ b/ui/browsing/nowplayingpage.go
@@ -2,6 +2,7 @@ package browsing
 
 import (
 	"supersonic/backend"
+	"supersonic/sharedutil"
 	"supersonic/ui/controller"
 	"supersonic/ui/layouts"
 	"supersonic/ui/widgets"
@@ -44,8 +45,9 @@ func NewNowPlayingPage(
 	a.tracklist.SetVisibleColumns(conf.TracklistColumns)
 	a.tracklist.AutoNumber = true
 	a.tracklist.DisablePlaybackMenu = true
+	contr.ConnectTracklistActions(a.tracklist)
+	// override the default OnPlayTrackAt handler b/c we don't need to re-load the tracks into the queue
 	a.tracklist.OnPlayTrackAt = a.onPlayTrackAt
-	a.tracklist.OnAddToPlaylist = a.contr.DoAddTracksToPlaylistWorkflow
 	a.tracklist.AuxiliaryMenuItems = []*fyne.MenuItem{
 		fyne.NewMenuItem("Remove from queue", a.onRemoveSelectedFromQueue),
 	}
@@ -86,7 +88,7 @@ func (a *NowPlayingPage) OnSongChange(song *subsonic.Child, lastScrobbledIfAny *
 		a.nowPlayingID = song.ID
 	}
 	a.tracklist.SetNowPlaying(a.nowPlayingID)
-	a.tracklist.IncrementPlayCount(lastScrobbledIfAny)
+	a.tracklist.IncrementPlayCount(sharedutil.TrackIDOrEmptyStr(lastScrobbledIfAny))
 }
 
 func (a *NowPlayingPage) Reload() {

--- a/ui/browsing/playlistpage.go
+++ b/ui/browsing/playlistpage.go
@@ -57,13 +57,7 @@ func NewPlaylistPage(
 		fyne.NewMenuItem("Remove from playlist", a.onRemoveSelectedFromPlaylist),
 	}
 	// connect tracklist actions
-	a.tracklist.OnPlayTrackAt = a.onPlayTrackAt
-	a.tracklist.OnAddToQueue = func(tracks []*subsonic.Child) { a.pm.LoadTracks(tracks, true, false) }
-	a.tracklist.OnPlaySelection = func(tracks []*subsonic.Child) {
-		a.pm.LoadTracks(tracks, false, false)
-		a.pm.PlayFromBeginning()
-	}
-	a.tracklist.OnAddToPlaylist = a.contr.DoAddTracksToPlaylistWorkflow
+	a.contr.ConnectTracklistActions(a.tracklist)
 
 	a.container = container.NewBorder(
 		container.New(&layouts.MaxPadLayout{PadLeft: 15, PadRight: 15, PadTop: 15, PadBottom: 10}, a.header),
@@ -106,11 +100,6 @@ func (a *PlaylistPage) Tapped(*fyne.PointEvent) {
 
 func (a *PlaylistPage) SelectAll() {
 	a.tracklist.SelectAll()
-}
-
-func (a *PlaylistPage) onPlayTrackAt(tracknum int) {
-	a.pm.LoadTracks(a.tracklist.Tracks, false, false)
-	a.pm.PlayTrackAt(tracknum)
 }
 
 // should be called asynchronously
@@ -163,7 +152,8 @@ func NewPlaylistPageHeader(page *PlaylistPage) *PlaylistPageHeader {
 	a.createdAtLabel = widget.NewLabel("")
 	a.trackTimeLabel = widget.NewLabel("")
 	playButton := widget.NewButtonWithIcon("Play", theme.MediaPlayIcon(), func() {
-		page.onPlayTrackAt(0)
+		page.pm.LoadTracks(page.tracklist.Tracks, false, false)
+		page.pm.PlayFromBeginning()
 	})
 	// TODO: find way to pad shuffle svg rather than using a space in the label string
 	shuffleBtn := widget.NewButtonWithIcon(" Shuffle", res.ResShuffleInvertSvg, func() {

--- a/ui/browsing/playlistpage.go
+++ b/ui/browsing/playlistpage.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"supersonic/backend"
 	"supersonic/res"
+	"supersonic/sharedutil"
 	"supersonic/ui/controller"
 	"supersonic/ui/layouts"
 	"supersonic/ui/util"
@@ -87,7 +88,7 @@ func (a *PlaylistPage) OnSongChange(song *subsonic.Child, lastScrobbledIfAny *su
 		a.nowPlayingID = song.ID
 	}
 	a.tracklist.SetNowPlaying(a.nowPlayingID)
-	a.tracklist.IncrementPlayCount(lastScrobbledIfAny)
+	a.tracklist.IncrementPlayCount(sharedutil.TrackIDOrEmptyStr(lastScrobbledIfAny))
 }
 
 func (a *PlaylistPage) Reload() {

--- a/ui/browsing/router.go
+++ b/ui/browsing/router.go
@@ -95,7 +95,7 @@ func (r Router) CreatePage(rte Route) Page {
 	case Artists:
 		return NewArtistsGenresPage(false, r.App.ServerManager, r.OpenRoute)
 	case Favorites:
-		return NewFavoritesPage(r.Controller, r.App.ServerManager, r.App.PlaybackManager, r.App.LibraryManager, r.App.ImageManager, r.OpenRoute)
+		return NewFavoritesPage(&r.App.Config.FavoritesPage, r.Controller, r.App.ServerManager, r.App.PlaybackManager, r.App.LibraryManager, r.App.ImageManager, r.OpenRoute)
 	case Genre:
 		return NewGenrePage(rte.Arg, r.App.PlaybackManager, r.App.LibraryManager, r.App.ImageManager, r.OpenRoute)
 	case Genres:

--- a/ui/browsing/router.go
+++ b/ui/browsing/router.go
@@ -95,7 +95,7 @@ func (r Router) CreatePage(rte Route) Page {
 	case Artists:
 		return NewArtistsGenresPage(false, r.App.ServerManager, r.OpenRoute)
 	case Favorites:
-		return NewFavoritesPage(r.App.ServerManager, r.App.PlaybackManager, r.App.LibraryManager, r.App.ImageManager, r.OpenRoute)
+		return NewFavoritesPage(r.Controller, r.App.ServerManager, r.App.PlaybackManager, r.App.LibraryManager, r.App.ImageManager, r.OpenRoute)
 	case Genre:
 		return NewGenrePage(rte.Arg, r.App.PlaybackManager, r.App.LibraryManager, r.App.ImageManager, r.OpenRoute)
 	case Genres:

--- a/ui/controller/controller.go
+++ b/ui/controller/controller.go
@@ -55,6 +55,14 @@ func (m Controller) ConnectTracklistActions(tracklist *widgets.Tracklist) {
 		m.App.PlaybackManager.LoadTracks(tracks, false, false)
 		m.App.PlaybackManager.PlayFromBeginning()
 	}
+	tracklist.OnSetFavorite = func(trackIDs []string, fav bool) {
+		s := m.App.ServerManager.Server
+		if fav {
+			go s.Star(subsonic.StarParameters{SongIDs: trackIDs})
+		} else {
+			go s.Unstar(subsonic.StarParameters{SongIDs: trackIDs})
+		}
+	}
 }
 
 func (m Controller) PromptForFirstServer() {

--- a/ui/controller/controller.go
+++ b/ui/controller/controller.go
@@ -62,6 +62,9 @@ func (m Controller) ConnectTracklistActions(tracklist *widgets.Tracklist) {
 		} else {
 			go s.Unstar(subsonic.StarParameters{SongIDs: trackIDs})
 		}
+		for _, id := range trackIDs {
+			m.App.PlaybackManager.OnTrackFavoriteStatusChanged(id, fav)
+		}
 	}
 }
 

--- a/ui/controller/controller.go
+++ b/ui/controller/controller.go
@@ -6,12 +6,14 @@ import (
 	"supersonic/backend"
 	"supersonic/ui/dialogs"
 	"supersonic/ui/util"
+	"supersonic/ui/widgets"
 	"time"
 
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/canvas"
 	"fyne.io/fyne/v2/dialog"
 	"fyne.io/fyne/v2/widget"
+	"github.com/dweymouth/go-subsonic/subsonic"
 )
 
 type Controller struct {
@@ -38,6 +40,21 @@ func (m Controller) ShowPopUpImage(img image.Image) {
 		(s.Width-popS.Width)/2,
 		(s.Height-popS.Height)/2,
 	))
+}
+
+func (m Controller) ConnectTracklistActions(tracklist *widgets.Tracklist) {
+	tracklist.OnAddToPlaylist = m.DoAddTracksToPlaylistWorkflow
+	tracklist.OnAddToQueue = func(tracks []*subsonic.Child) {
+		m.App.PlaybackManager.LoadTracks(tracks, true, false)
+	}
+	tracklist.OnPlayTrackAt = func(idx int) {
+		m.App.PlaybackManager.LoadTracks(tracklist.Tracks, false, false)
+		m.App.PlaybackManager.PlayTrackAt(idx)
+	}
+	tracklist.OnPlaySelection = func(tracks []*subsonic.Child) {
+		m.App.PlaybackManager.LoadTracks(tracks, false, false)
+		m.App.PlaybackManager.PlayFromBeginning()
+	}
 }
 
 func (m Controller) PromptForFirstServer() {

--- a/ui/layouts/hboxcustompadding.go
+++ b/ui/layouts/hboxcustompadding.go
@@ -1,0 +1,58 @@
+package layouts
+
+import (
+	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/theme"
+)
+
+var _ fyne.Layout = (*VboxCustomPadding)(nil)
+
+type HboxCustomPadding struct {
+	ExtraPad        float32
+	DisableThemePad bool
+}
+
+func (v *HboxCustomPadding) MinSize(objects []fyne.CanvasObject) fyne.Size {
+	minSize := fyne.NewSize(0, 0)
+	for _, child := range objects {
+		if !child.Visible() {
+			continue
+		}
+
+		minSize.Height = fyne.Max(child.MinSize().Height, minSize.Height)
+		minSize.Width += child.MinSize().Width
+	}
+	minSize.Width += (v.themePad() + v.ExtraPad) * float32(len(objects)-1)
+	return minSize
+}
+
+func (v *HboxCustomPadding) Layout(objects []fyne.CanvasObject, size fyne.Size) {
+	total := float32(0)
+	for _, child := range objects {
+		if !child.Visible() {
+			continue
+		}
+		total += child.MinSize().Width
+	}
+
+	x, y := float32(0), float32(0)
+
+	extra := float32(0)
+	for _, child := range objects {
+		if !child.Visible() {
+			continue
+		}
+		width := child.MinSize().Width
+		child.Move(fyne.NewPos(x+extra, y))
+		x += width
+		child.Resize(fyne.NewSize(width, size.Height))
+		extra += (v.themePad() + v.ExtraPad)
+	}
+}
+
+func (v *HboxCustomPadding) themePad() float32 {
+	if v.DisableThemePad {
+		return 0
+	}
+	return theme.Padding()
+}

--- a/ui/widgets/auxcontrols.go
+++ b/ui/widgets/auxcontrols.go
@@ -3,7 +3,6 @@ package widgets
 import (
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/container"
-	"fyne.io/fyne/v2/driver/desktop"
 	"fyne.io/fyne/v2/layout"
 	"fyne.io/fyne/v2/theme"
 	"fyne.io/fyne/v2/widget"
@@ -56,37 +55,10 @@ func (v *volumeSlider) MinSize() fyne.Size {
 	return fyne.NewSize(v.Width, h)
 }
 
-type tappableIcon struct {
-	widget.Icon
-
-	OnTapped func()
-}
-
-func newTappableIcon(res fyne.Resource) *tappableIcon {
-	icon := &tappableIcon{}
-	icon.ExtendBaseWidget(icon)
-	icon.SetResource(res)
-
-	return icon
-}
-
-func (t *tappableIcon) Tapped(_ *fyne.PointEvent) {
-	if t.OnTapped != nil {
-		t.OnTapped()
-	}
-}
-
-func (t *tappableIcon) TappedSecondary(_ *fyne.PointEvent) {
-}
-
-func (t *tappableIcon) Cursor() desktop.Cursor {
-	return desktop.PointerCursor
-}
-
 type VolumeControl struct {
 	widget.BaseWidget
 
-	icon   *tappableIcon
+	icon   *TappableIcon
 	slider *volumeSlider
 
 	OnVolumeChanged func(int)
@@ -100,7 +72,7 @@ type VolumeControl struct {
 func NewVolumeControl(initialVol int) *VolumeControl {
 	v := &VolumeControl{}
 	v.ExtendBaseWidget(v)
-	v.icon = newTappableIcon(theme.VolumeUpIcon())
+	v.icon = NewTappbaleIcon(theme.VolumeUpIcon())
 	v.icon.OnTapped = v.toggleMute
 	v.slider = NewVolumeSlider(100)
 	v.lastVol = initialVol

--- a/ui/widgets/tappableicon.go
+++ b/ui/widgets/tappableicon.go
@@ -1,0 +1,34 @@
+package widgets
+
+import (
+	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/driver/desktop"
+	"fyne.io/fyne/v2/widget"
+)
+
+type TappableIcon struct {
+	widget.Icon
+
+	OnTapped func()
+}
+
+func NewTappbaleIcon(res fyne.Resource) *TappableIcon {
+	icon := &TappableIcon{}
+	icon.ExtendBaseWidget(icon)
+	icon.SetResource(res)
+
+	return icon
+}
+
+func (t *TappableIcon) Tapped(_ *fyne.PointEvent) {
+	if t.OnTapped != nil {
+		t.OnTapped()
+	}
+}
+
+func (t *TappableIcon) TappedSecondary(_ *fyne.PointEvent) {
+}
+
+func (t *TappableIcon) Cursor() desktop.Cursor {
+	return desktop.PointerCursor
+}

--- a/ui/widgets/togglebuttongroup.go
+++ b/ui/widgets/togglebuttongroup.go
@@ -1,0 +1,64 @@
+package widgets
+
+import (
+	"supersonic/ui/layouts"
+
+	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/container"
+	"fyne.io/fyne/v2/widget"
+)
+
+type ToggleButtonGroup struct {
+	widget.BaseWidget
+
+	buttonContainer *fyne.Container
+
+	activeBtnIdx int
+}
+
+func NewToggleButtonGroup(activatedBtnIdx int, buttons ...*widget.Button) *ToggleButtonGroup {
+	t := &ToggleButtonGroup{}
+	t.ExtendBaseWidget(t)
+	t.buttonContainer = container.New(&layouts.HboxCustomPadding{DisableThemePad: true})
+	for i, b := range buttons {
+		b.Importance = widget.MediumImportance
+		t.buttonContainer.Add(b)
+		prevOnTapped := b.OnTapped
+		b.OnTapped = func(i int) func() {
+			return func() {
+				if t.onTapped(i) && prevOnTapped != nil {
+					prevOnTapped()
+				}
+			}
+		}(i)
+	}
+	if activatedBtnIdx >= 0 && activatedBtnIdx <= len(buttons) {
+		buttons[activatedBtnIdx].Importance = widget.HighImportance
+	}
+
+	return t
+}
+
+func (t *ToggleButtonGroup) ActivatedButtonIndex() int {
+	return t.activeBtnIdx
+}
+
+func (t *ToggleButtonGroup) onTapped(btnIdx int) bool {
+	for i, b := range t.buttonContainer.Objects {
+		if i == btnIdx {
+			b.(*widget.Button).Importance = widget.HighImportance
+		} else {
+			b.(*widget.Button).Importance = widget.MediumImportance
+		}
+	}
+	changed := t.activeBtnIdx != btnIdx
+	t.activeBtnIdx = btnIdx
+	if changed {
+		t.Refresh()
+	}
+	return changed
+}
+
+func (t *ToggleButtonGroup) CreateRenderer() fyne.WidgetRenderer {
+	return widget.NewSimpleRenderer(t.buttonContainer)
+}

--- a/ui/widgets/togglebuttongroup.go
+++ b/ui/widgets/togglebuttongroup.go
@@ -43,19 +43,24 @@ func (t *ToggleButtonGroup) ActivatedButtonIndex() int {
 	return t.activeBtnIdx
 }
 
-func (t *ToggleButtonGroup) onTapped(btnIdx int) bool {
+func (t *ToggleButtonGroup) SetActivatedButton(idx int) {
+	changed := t.activeBtnIdx != idx
+	t.activeBtnIdx = idx
 	for i, b := range t.buttonContainer.Objects {
-		if i == btnIdx {
+		if i == idx {
 			b.(*widget.Button).Importance = widget.HighImportance
 		} else {
 			b.(*widget.Button).Importance = widget.MediumImportance
 		}
 	}
-	changed := t.activeBtnIdx != btnIdx
-	t.activeBtnIdx = btnIdx
 	if changed {
 		t.Refresh()
 	}
+}
+
+func (t *ToggleButtonGroup) onTapped(btnIdx int) bool {
+	changed := t.activeBtnIdx != btnIdx
+	t.SetActivatedButton(btnIdx)
 	return changed
 }
 

--- a/ui/widgets/tracklist.go
+++ b/ui/widgets/tracklist.go
@@ -5,6 +5,7 @@ import (
 	"runtime"
 	"strconv"
 	"supersonic/res"
+	"supersonic/sharedutil"
 	"supersonic/ui/layouts"
 	"supersonic/ui/os"
 	"supersonic/ui/util"
@@ -150,16 +151,10 @@ func (t *Tracklist) SetNowPlaying(trackID string) {
 	t.Refresh()
 }
 
-func (t *Tracklist) IncrementPlayCount(track *subsonic.Child) {
-	if track == nil {
-		return
-	}
-	for _, tr := range t.Tracks {
-		if tr.ID == track.ID {
-			tr.PlayCount += 1
-			t.Refresh()
-			return
-		}
+func (t *Tracklist) IncrementPlayCount(trackID string) {
+	if tr := sharedutil.FindTrackByID(trackID, t.Tracks); tr != nil {
+		tr.PlayCount += 1
+		t.Refresh()
 	}
 }
 
@@ -245,6 +240,14 @@ func (t *Tracklist) onShowContextMenu(e *fyne.PointEvent, trackIdx int) {
 }
 
 func (t *Tracklist) onSetFavorite(trackID string, fav bool) {
+	// update our own track model
+	tr := sharedutil.FindTrackByID(trackID, t.Tracks)
+	if fav {
+		tr.Starred = time.Now()
+	} else {
+		tr.Starred = time.Time{}
+	}
+	// notify listener
 	if t.OnSetFavorite != nil {
 		t.OnSetFavorite([]string{trackID}, fav)
 	}


### PR DESCRIPTION
This PR is closing #51 and also closing #52 

Changes include:
* add favorite column to the tracklist widget for toggling track favorited status
* add favorite button to the Artist page header
* add list views for favorite artists and songs to the Favorite page
* add a toggle button group to the favorite page to toggle between the 3 views
* make sure all 3 favorites page views' data models update on page reload
* fixing a bug (#52)
* new config struct for Favorites page to save the view preferences