### PR TITLE
Adding Arch Linux build instructions to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Supersonic is available in the AUR and can be built either manually with `makepk
 * Make sure you have the base-devel package group installed on your system
   - ``sudo pacman -S --needed base-devel``
 * Clone the AUR repository and navigate into the cloned directory
-  - ``git clone https://aur.archlinux.org/packages/supersonic-desktop.git && cd supersonic-desktop``
+  - ``git clone https://aur.archlinux.org/supersonic-desktop.git && cd supersonic-desktop``
 * Build the package with makepkg
   - ``makepkg -si``
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,22 @@ Download the latest [release](https://github.com/dweymouth/supersonic/releases) 
 * (note that the first build will take some time as it will download and build the UI library)
 * run ``make package_linux`` to generate an installable .tar.xz bundle
 
+## Build instructions (Arch Linux)
+
+Supersonic is available in the AUR and can be built either manually with `makepkg` or with an AUR helper like [yay](https://github.com/Jguer/yay).
+
+### Build manually
+* Make sure you have the base-devel package group installed on your system
+  - ``sudo pacman -S --needed base-devel``
+* Clone the AUR repository and navigate into the cloned directory
+  - ``git clone https://aur.archlinux.org/packages/supersonic-desktop.git && cd supersonic-desktop``
+* Build the package with makepkg
+  - ``makepkg -si``
+
+### Build with an AUR helper
+* Invoke your favorite AUR helper to automatically build the package
+  - ``yay -S supersonic-desktop``
+
 ## Build instructions (Mac OS)
 
 ### Install dependencies


### PR DESCRIPTION
This pull request adds the build instructions for Arch Linux in the README.

As per our discussion in #126 , the Arch Linux PKGBUILD is ready and is already available in the AUR.

You can see additional details [here](https://aur.archlinux.org/packages/supersonic-desktop).