### PR TITLE
Temporarily add tappable behavior to volume slider until Fyne 2.4

### DIFF
--- a/ui/widgets/auxcontrols.go
+++ b/ui/widgets/auxcontrols.go
@@ -61,6 +61,49 @@ func (v *volumeSlider) Scrolled(e *fyne.ScrollEvent) {
 	v.SetValue(v.Value + float64(0.5*e.Scrolled.DY))
 }
 
+// This code will be OBSOLETE in Fyne 2.4
+// which will natively add Tappable behavior to slider
+// Tapped is called when a pointer tapped event is captured.
+//
+// Since: 2.4
+func (v *volumeSlider) Tapped(e *fyne.PointEvent) {
+	ratio := v.getRatio(e)
+	val := v.Min + ratio*(v.Max-v.Min)
+	v.SetValue(val)
+	v.DragEnd()
+}
+
+func (v *volumeSlider) endOffset() float32 {
+	return (theme.IconInlineSize()-4)/2 + theme.InnerPadding() - 1.5 // align with radio icons
+}
+
+func (v *volumeSlider) getRatio(e *fyne.PointEvent) float64 {
+	pad := v.endOffset()
+
+	x := e.Position.X
+	y := e.Position.Y
+
+	switch v.Orientation {
+	case widget.Vertical:
+		if y > v.Size().Height-pad {
+			return 0.0
+		} else if y < pad {
+			return 1.0
+		} else {
+			return 1 - float64(y-pad)/float64(v.Size().Height-pad*2)
+		}
+	case widget.Horizontal:
+		if x > v.Size().Width-pad {
+			return 1.0
+		} else if x < pad {
+			return 0.0
+		} else {
+			return float64(x-pad) / float64(v.Size().Width-pad*2)
+		}
+	}
+	return 0.0
+}
+
 type VolumeControl struct {
 	widget.BaseWidget
 


### PR DESCRIPTION
Same code as https://github.com/dweymouth/supersonic/commit/a9cec173ddcd0999cfbe7f61ca15c01bd3c1cbce, but for the volume slider.

Related issue: #95