### PR TITLE
Scrobble playing track when removed from queue

### DIFF
--- a/backend/playbackmanager.go
+++ b/backend/playbackmanager.go
@@ -60,8 +60,7 @@ func NewPlaybackManager(
 		if tracknum >= int64(len(pm.playQueue)) {
 			return
 		}
-		pm.checkScrobble(pm.playTimeStopwatch.Elapsed())
-		pm.playTimeStopwatch.Reset()
+		pm.checkScrobble()
 		if pm.player.GetStatus().State == player.Playing {
 			pm.playTimeStopwatch.Start()
 		}
@@ -76,8 +75,7 @@ func NewPlaybackManager(
 	})
 	p.OnStopped(func() {
 		pm.playTimeStopwatch.Stop()
-		pm.checkScrobble(pm.playTimeStopwatch.Elapsed())
-		pm.playTimeStopwatch.Reset()
+		pm.checkScrobble()
 		pm.stopPollTimePos()
 		pm.doUpdateTimePos()
 		pm.invokeOnSongChangeCallbacks()
@@ -255,7 +253,7 @@ func (p *PlaybackManager) RemoveTracksFromQueue(trackIDs []string) {
 			if i == p.NowPlayingIndex() {
 				isPlayingTrackRemoved = true
 				// If we are removing the currently playing track, we need to scrobble it
-				p.checkScrobble(p.playTimeStopwatch.Elapsed())
+				p.checkScrobble()
 			}
 			if err := p.player.RemoveTrackAt(i - rmCount); err == nil {
 				rmCount++
@@ -294,10 +292,11 @@ func (p *PlaybackManager) SetReplayGainOptions(config ReplayGainConfig) {
 }
 
 // call BEFORE updating p.nowPlayingIdx
-func (p *PlaybackManager) checkScrobble(playDur time.Duration) {
+func (p *PlaybackManager) checkScrobble() {
 	if !p.scrobbleCfg.Enabled || len(p.playQueue) == 0 || p.nowPlayingIdx < 0 {
 		return
 	}
+	playDur := p.playTimeStopwatch.Elapsed()
 	if playDur.Seconds() < 0.1 || p.curTrackTime < 0.1 {
 		return
 	}
@@ -311,6 +310,7 @@ func (p *PlaybackManager) checkScrobble(playDur time.Duration) {
 		p.lastScrobbled = song
 		go p.sm.Server.Scrobble(song.ID, true)
 	}
+	p.playTimeStopwatch.Reset()
 }
 
 func (p *PlaybackManager) sendNowPlayingScrobble() {


### PR DESCRIPTION
This change fixes two `TODO` comments, by scrobbling the currently playing track if it's removed from the queue, and only run OnSongChange callbacks when the playing track is affected.