### PR TITLE
Add Loop functionality to player controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <img src="res/appicon-128.png" alt="Supersonic logo" title="Supersonic" align="left" height="60px"/>
 <a href='https://flathub.org/apps/details/io.github.dweymouth.supersonic'><img height="50px" align="right" alt='Download on Flathub' src='https://flathub.org/assets/badges/flathub-badge-en.png'/></a></div>
-<a href='https://ko-fi.com/dweymouth' target='_blank'><img height='40' align='right' src='https://az743702.vo.msecnd.net/cdn/kofi3.png?v=0' border='0' alt='Buy Me a Coffee at ko-fi.com'/>  
-  
+<a href='https://ko-fi.com/dweymouth' target='_blank'><img height='40' align='right' src='https://az743702.vo.msecnd.net/cdn/kofi3.png?v=0' border='0' alt='Buy Me a Coffee at ko-fi.com'/>
+
 # Supersonic
 
 [![License](https://img.shields.io/github/license/dweymouth/supersonic)](https://github.com/dweymouth/supersonic/blob/main/LICENSE)
@@ -40,7 +40,7 @@ Screenshots of Supersonic running against the Navidrome [demo server](https://ww
 * [x] Set/unset favorite and browse by favorite albums, artists, and songs
 * [x] Set and view track rating (0-5 stars)
 * [x] View and edit play queue (add and remove tracks; reorder support coming soon)
-* [x] Shuffle and repeat playback modes (partial; shuffle album, playlist, artist radio, random songs)
+* [x] Shuffle and repeat playback modes (partial; shuffle album, playlist, artist radio, random songs; repeat all)
 * [ ] Browse by folders (planned)
 * [ ] Download songs, albums or playlists (planned)
 * [ ] Cast to uPnP/DLNA devices (likely planned)
@@ -86,7 +86,7 @@ Supersonic is available in the AUR and can be built either manually with `makepk
 
 ### Build with an AUR helper
 * Invoke your favorite AUR helper to automatically build the package
-  - ``yay -S supersonic-desktop`` 
+  - ``yay -S supersonic-desktop``
 
 ## Build instructions (Mac OS)
 

--- a/backend/playbackmanager.go
+++ b/backend/playbackmanager.go
@@ -304,11 +304,9 @@ func (p *PlaybackManager) SetNextLoopMode() error {
 		return err
 	}
 
-	defer func() {
-		for _, cb := range p.onLoopModeChange {
-			cb(p.player.GetLoopMode().String())
-		}
-	}()
+	for _, cb := range p.onLoopModeChange {
+		cb(p.player.GetLoopMode().String())
+	}
 
 	return nil
 }

--- a/backend/playbackmanager.go
+++ b/backend/playbackmanager.go
@@ -40,6 +40,7 @@ type PlaybackManager struct {
 
 	onSongChange     []func(nowPlaying, justScrobbledIfAny *mediaprovider.Track)
 	onPlayTimeUpdate []func(float64, float64)
+	onLoopModeChange []func(string)
 }
 
 func NewPlaybackManager(
@@ -126,6 +127,11 @@ func (p *PlaybackManager) OnSongChange(cb func(nowPlaying *mediaprovider.Track, 
 // Registers a callback that is notified whenever the play time should be updated.
 func (p *PlaybackManager) OnPlayTimeUpdate(cb func(float64, float64)) {
 	p.onPlayTimeUpdate = append(p.onPlayTimeUpdate, cb)
+}
+
+// Registers a callback that is notified whenever the loop mode changes.
+func (p *PlaybackManager) OnLoopModeChange(cb func(string)) {
+	p.onLoopModeChange = append(p.onLoopModeChange, cb)
 }
 
 // Loads the specified album into the play queue.
@@ -294,7 +300,17 @@ func (p *PlaybackManager) SetReplayGainOptions(config ReplayGainConfig) {
 // Changes the loop mode of the player to the next one.
 // Useful for toggling UI elements, to change modes without knowing the current player mode.
 func (p *PlaybackManager) SetNextLoopMode() error {
-	return p.player.SetNextLoopMode()
+	if err := p.player.SetNextLoopMode(); err != nil {
+		return err
+	}
+
+	defer func() {
+		for _, cb := range p.onLoopModeChange {
+			cb(p.player.GetLoopMode().String())
+		}
+	}()
+
+	return nil
 }
 
 // call BEFORE updating p.nowPlayingIdx

--- a/backend/playbackmanager.go
+++ b/backend/playbackmanager.go
@@ -291,6 +291,12 @@ func (p *PlaybackManager) SetReplayGainOptions(config ReplayGainConfig) {
 	})
 }
 
+// Changes the loop mode of the player to the next one.
+// Useful for toggling UI elements, to change modes without knowing the current player mode.
+func (p *PlaybackManager) SetNextLoopMode() error {
+	return p.player.SetNextLoopMode()
+}
+
 // call BEFORE updating p.nowPlayingIdx
 func (p *PlaybackManager) checkScrobble() {
 	if !p.scrobbleCfg.Enabled || len(p.playQueue) == 0 || p.nowPlayingIdx < 0 {

--- a/ui/bottompanel.go
+++ b/ui/bottompanel.go
@@ -55,7 +55,7 @@ func NewBottomPanel(p *player.Player, pm *backend.PlaybackManager, contr *contro
 		bp.Controls.SetPlaying(false)
 	})
 	pm.OnLoopModeChange(func(mode string) {
-		bp.Controls.SetLoopMode(mode)
+		bp.AuxControls.SetLoopMode(mode)
 	})
 
 	bp.NowPlaying = widgets.NewNowPlayingCard()
@@ -98,14 +98,14 @@ func NewBottomPanel(p *player.Player, pm *backend.PlaybackManager, contr *contro
 	bp.Controls.OnSeek(func(f float64) {
 		p.Seek(fmt.Sprintf("%d", int(f*100)), player.SeekAbsolutePercent)
 	})
-	bp.Controls.OnChangeLoopMode(func() {
-		bp.playbackManager.SetNextLoopMode()
-	})
 
 	bp.AuxControls = widgets.NewAuxControls(p.GetVolume())
 	bp.AuxControls.VolumeControl.OnVolumeChanged = func(v int) {
 		_ = p.SetVolume(v)
 	}
+	bp.AuxControls.OnChangeLoopMode(func() {
+		bp.playbackManager.SetNextLoopMode()
+	})
 
 	bp.container = container.New(layouts.NewLeftMiddleRightLayout(500),
 		bp.NowPlaying, bp.Controls, bp.AuxControls)

--- a/ui/bottompanel.go
+++ b/ui/bottompanel.go
@@ -54,7 +54,7 @@ func NewBottomPanel(p *player.Player, pm *backend.PlaybackManager, contr *contro
 	p.OnStopped(func() {
 		bp.Controls.SetPlaying(false)
 	})
-	p.OnLoopModeChanged(func(mode string) {
+	pm.OnLoopModeChange(func(mode string) {
 		bp.Controls.SetLoopMode(mode)
 	})
 

--- a/ui/bottompanel.go
+++ b/ui/bottompanel.go
@@ -46,6 +46,9 @@ func NewBottomPanel(p *player.Player, contr *controller.Controller) *BottomPanel
 	p.OnStopped(func() {
 		bp.Controls.SetPlaying(false)
 	})
+	p.OnLoopModeChanged(func(mode string) {
+		bp.Controls.SetLoopMode(mode)
+	})
 
 	bp.NowPlaying = widgets.NewNowPlayingCard()
 	bp.NowPlaying.OnShowCoverImage = func() {
@@ -86,6 +89,9 @@ func NewBottomPanel(p *player.Player, contr *controller.Controller) *BottomPanel
 	})
 	bp.Controls.OnSeek(func(f float64) {
 		p.Seek(fmt.Sprintf("%d", int(f*100)), player.SeekAbsolutePercent)
+	})
+	bp.Controls.OnChangeLoopMode(func() {
+		p.SetNextLoopMode()
 	})
 
 	bp.AuxControls = widgets.NewAuxControls(p.GetVolume())

--- a/ui/mainwindow.go
+++ b/ui/mainwindow.go
@@ -75,8 +75,7 @@ func NewMainWindow(fyneApp fyne.App, appName, appVersion string, app *backend.Ap
 	m.Controller.ReloadFunc = m.BrowsingPane.Reload
 	m.Controller.CurPageFunc = m.BrowsingPane.CurrentPage
 
-	m.BottomPanel = NewBottomPanel(app.Player, m.Controller)
-	m.BottomPanel.SetPlaybackManager(app.PlaybackManager)
+	m.BottomPanel = NewBottomPanel(app.Player, app.PlaybackManager, m.Controller)
 	m.BottomPanel.ImageManager = app.ImageManager
 	m.container = container.NewBorder(nil, m.BottomPanel, nil, nil, m.BrowsingPane)
 	m.Window.SetContent(m.container)

--- a/ui/widgets/auxcontrols.go
+++ b/ui/widgets/auxcontrols.go
@@ -6,6 +6,7 @@ import (
 	"fyne.io/fyne/v2/layout"
 	"fyne.io/fyne/v2/theme"
 	"fyne.io/fyne/v2/widget"
+	"github.com/dweymouth/supersonic/ui/util"
 )
 
 // The "aux" controls for playback, positioned to the right
@@ -14,22 +15,41 @@ type AuxControls struct {
 	widget.BaseWidget
 
 	VolumeControl *VolumeControl
-	loop          *widget.Button
+	loop          *miniButton
 
 	container *fyne.Container
+}
+
+type miniButton struct {
+	widget.Button
+}
+
+func newMiniButton(icon fyne.Resource) *miniButton {
+	b := &miniButton{
+		Button: widget.Button{
+			Icon: icon,
+		},
+	}
+	b.ExtendBaseWidget(b)
+	return b
+}
+
+func (b *miniButton) MinSize() fyne.Size {
+	return fyne.NewSize(24, 24)
 }
 
 func NewAuxControls(initialVolume int) *AuxControls {
 	a := &AuxControls{
 		VolumeControl: NewVolumeControl(initialVolume),
-		loop:          widget.NewButtonWithIcon("", theme.MediaReplayIcon(), func() {}),
+		loop:          newMiniButton(theme.MediaReplayIcon()),
 	}
 	a.container = container.NewHBox(
 		layout.NewSpacer(),
 		container.NewVBox(
+			util.NewHSpace(0), // hack to move everything down a tiny bit
 			layout.NewSpacer(),
 			a.VolumeControl,
-			container.NewCenter(layout.NewSpacer(), a.loop),
+			container.NewHBox(layout.NewSpacer(), a.loop, util.NewHSpace(5)),
 			layout.NewSpacer(),
 		),
 	)

--- a/ui/widgets/auxcontrols.go
+++ b/ui/widgets/auxcontrols.go
@@ -14,6 +14,7 @@ type AuxControls struct {
 	widget.BaseWidget
 
 	VolumeControl *VolumeControl
+	loop          *widget.Button
 
 	container *fyne.Container
 }
@@ -21,14 +22,36 @@ type AuxControls struct {
 func NewAuxControls(initialVolume int) *AuxControls {
 	a := &AuxControls{
 		VolumeControl: NewVolumeControl(initialVolume),
+		loop:          widget.NewButtonWithIcon("", theme.MediaReplayIcon(), func() {}),
 	}
-	a.container = container.NewHBox(layout.NewSpacer(), a.VolumeControl)
+	a.container = container.NewHBox(
+		layout.NewSpacer(),
+		container.NewVBox(
+			layout.NewSpacer(),
+			a.VolumeControl,
+			container.NewCenter(layout.NewSpacer(), a.loop),
+			layout.NewSpacer(),
+		),
+	)
 	return a
 }
 
 func (a *AuxControls) CreateRenderer() fyne.WidgetRenderer {
 	a.ExtendBaseWidget(a)
 	return widget.NewSimpleRenderer(a.container)
+}
+
+func (a *AuxControls) OnChangeLoopMode(f func()) {
+	a.loop.OnTapped = f
+}
+
+func (a *AuxControls) SetLoopMode(mode string) {
+	if mode == "all" {
+		a.loop.Importance = widget.HighImportance
+	} else {
+		a.loop.Importance = widget.MediumImportance
+	}
+	a.loop.Refresh()
 }
 
 type volumeSlider struct {

--- a/ui/widgets/playercontrols.go
+++ b/ui/widgets/playercontrols.go
@@ -10,6 +10,10 @@ import (
 	"fyne.io/fyne/v2/widget"
 )
 
+var (
+	themedResReplay = theme.NewThemedResource(theme.MediaReplayIcon())
+)
+
 // TrackPosSlider is a custom slider that doesn't trigger
 // the seek action until drag end.
 type TrackPosSlider struct {
@@ -62,6 +66,7 @@ type PlayerControls struct {
 	prev           *widget.Button
 	playpause      *widget.Button
 	next           *widget.Button
+	loop           *widget.Button
 	container      *fyne.Container
 
 	totalTime float64
@@ -105,8 +110,9 @@ func NewPlayerControls() *PlayerControls {
 	pc.prev = widget.NewButtonWithIcon("", theme.MediaSkipPreviousIcon(), func() {})
 	pc.next = widget.NewButtonWithIcon("", theme.MediaSkipNextIcon(), func() {})
 	pc.playpause = widget.NewButtonWithIcon("", theme.MediaPlayIcon(), func() {})
+	pc.loop = widget.NewButtonWithIcon("", themedResReplay, func() {})
 
-	buttons := container.NewHBox(pc.prev, pc.playpause, pc.next)
+	buttons := container.NewHBox(pc.prev, pc.playpause, pc.next, pc.loop)
 	b := container.New(layout.NewCenterLayout(), buttons)
 
 	c := container.NewBorder(nil, nil, pc.curTimeLabel, pc.totalTimeLabel, pc.slider)
@@ -136,6 +142,20 @@ func (pc *PlayerControls) SetPlaying(playing bool) {
 		pc.playpause.SetIcon(theme.MediaPauseIcon())
 	} else {
 		pc.playpause.SetIcon(theme.MediaPlayIcon())
+	}
+}
+
+func (pc *PlayerControls) OnChangeLoopMode(f func()) {
+	pc.loop.OnTapped = f
+}
+
+func (pc *PlayerControls) SetLoopMode(mode string) {
+	if mode == "all" {
+		themedResReplay.ColorName = theme.ColorNameSuccess
+		pc.loop.SetIcon(themedResReplay)
+	} else {
+		themedResReplay.ColorName = ""
+		pc.loop.SetIcon(themedResReplay)
 	}
 }
 

--- a/ui/widgets/playercontrols.go
+++ b/ui/widgets/playercontrols.go
@@ -10,10 +10,6 @@ import (
 	"fyne.io/fyne/v2/widget"
 )
 
-var (
-	themedResReplay = theme.NewThemedResource(theme.MediaReplayIcon())
-)
-
 // TrackPosSlider is a custom slider that doesn't trigger
 // the seek action until drag end.
 type TrackPosSlider struct {
@@ -66,7 +62,6 @@ type PlayerControls struct {
 	prev           *widget.Button
 	playpause      *widget.Button
 	next           *widget.Button
-	loop           *widget.Button
 	container      *fyne.Container
 
 	totalTime float64
@@ -110,9 +105,8 @@ func NewPlayerControls() *PlayerControls {
 	pc.prev = widget.NewButtonWithIcon("", theme.MediaSkipPreviousIcon(), func() {})
 	pc.next = widget.NewButtonWithIcon("", theme.MediaSkipNextIcon(), func() {})
 	pc.playpause = widget.NewButtonWithIcon("", theme.MediaPlayIcon(), func() {})
-	pc.loop = widget.NewButtonWithIcon("", themedResReplay, func() {})
 
-	buttons := container.NewHBox(pc.prev, pc.playpause, pc.next, pc.loop)
+	buttons := container.NewHBox(pc.prev, pc.playpause, pc.next)
 	b := container.New(layout.NewCenterLayout(), buttons)
 
 	c := container.NewBorder(nil, nil, pc.curTimeLabel, pc.totalTimeLabel, pc.slider)
@@ -142,20 +136,6 @@ func (pc *PlayerControls) SetPlaying(playing bool) {
 		pc.playpause.SetIcon(theme.MediaPauseIcon())
 	} else {
 		pc.playpause.SetIcon(theme.MediaPlayIcon())
-	}
-}
-
-func (pc *PlayerControls) OnChangeLoopMode(f func()) {
-	pc.loop.OnTapped = f
-}
-
-func (pc *PlayerControls) SetLoopMode(mode string) {
-	if mode == "all" {
-		themedResReplay.ColorName = theme.ColorNameSuccess
-		pc.loop.SetIcon(themedResReplay)
-	} else {
-		themedResReplay.ColorName = ""
-		pc.loop.SetIcon(themedResReplay)
 	}
 }
 


### PR DESCRIPTION
Adding the Loop functionality, along with the Player changes to support it, and a button to the player controls.

`Player` now has a `loopMode` attribute, which determines whether it should loop. At the moment, only the following modes are supported:

* `LoopNone`: Disables loop.
* `LoopAll`: Enables loop for the entire playlist queue.

This has been designed as an enum, to support other modes in the future (e.g. loop for the current track only).

It depends on the `loop` functionality provided by MPV (using the [`loop-playlist` option](https://mpv.io/manual/master/#options-loop-playlist)), so no custom logic is needed to reset the currently playing index.