### PR TITLE
Ability to download album and playlist

### DIFF
--- a/ui/browsing/albumpage.go
+++ b/ui/browsing/albumpage.go
@@ -200,6 +200,9 @@ func NewAlbumPageHeader(page *AlbumPage) *AlbumPageHeader {
 				fyne.NewMenuItem("Add to playlist...", func() {
 					a.page.contr.DoAddTracksToPlaylistWorkflow(
 						sharedutil.TracksToIDs(a.page.tracks))
+				}),
+				fyne.NewMenuItem("Download", func() {
+					a.page.contr.ShowDownloadDialog(a.page.tracks)
 				}))
 			pop = widget.NewPopUpMenu(menu, fyne.CurrentApp().Driver().CanvasForObject(a))
 		}

--- a/ui/browsing/playlistpage.go
+++ b/ui/browsing/playlistpage.go
@@ -260,6 +260,9 @@ func NewPlaylistPageHeader(page *PlaylistPage) *PlaylistPageHeader {
 				fyne.NewMenuItem("Add to playlist...", func() {
 					a.page.contr.DoAddTracksToPlaylistWorkflow(
 						sharedutil.TracksToIDs(a.page.tracks))
+				}),
+				fyne.NewMenuItem("Download", func() {
+					a.page.contr.ShowDownloadDialog(a.page.tracks)
 				}))
 			pop = widget.NewPopUpMenu(menu, fyne.CurrentApp().Driver().CanvasForObject(a))
 		}


### PR DESCRIPTION
Add in the "meatball menu" of the Album and Playlist pages the option to download the tracks of the corresponding album or playlist in a zip file. When download is clicked, a dialog window appears allowing you to choose the file name and where to save the file.
![Screenshot from 2023-06-16 15-06-48](https://github.com/dweymouth/supersonic/assets/30585029/4ce7d05a-9f67-467c-8144-691399483c81)
![image](https://github.com/dweymouth/supersonic/assets/30585029/24439f2d-c800-42b0-9149-b493c20f2252)
