### PR TITLE
Add MinSize method to TappableImage

### DIFF
--- a/ui/widgets/tappablewrappers.go
+++ b/ui/widgets/tappablewrappers.go
@@ -82,9 +82,6 @@ func (t *TappableImage) Refresh() {
 }
 
 func (t *TappableImage) MinSize() fyne.Size {
-	if !t.haveImage() {
-		return fyne.NewSize(0, 0)
-	}
 	return t.Image.MinSize()
 }
 

--- a/ui/widgets/tappablewrappers.go
+++ b/ui/widgets/tappablewrappers.go
@@ -81,6 +81,13 @@ func (t *TappableImage) Refresh() {
 	t.BaseWidget.Refresh()
 }
 
+func (t *TappableImage) MinSize() fyne.Size {
+	if !t.haveImage() {
+		return fyne.NewSize(0, 0)
+	}
+	return t.Image.MinSize()
+}
+
 func (t *TappableImage) Resize(size fyne.Size) {
 	t.BaseWidget.Resize(size)
 }


### PR DESCRIPTION
This is being added, because testing the latest `develop` version for `fyne` fails with the following error:

```
ui/widgets/imageplaceholder.go:48:3: cannot use i.imageDisp (variable of type *TappableImage) as fyne.CanvasObject value in argument to container.NewMax: *TappableImage does not implement fyne.CanvasObject (missing method MinSize)
ui/widgets/nowplayingcard.go:51:33: cannot use n.cover (variable of type *TappableImage) as fyne.CanvasObject value in argument to container.NewBorder: *TappableImage does not implement fyne.CanvasObject (missing method MinSize)
ui/widgets/tappablewrappers.go:64:21: cannot use t (variable of type *TappableImage) as fyne.Widget value in argument to t.ExtendBaseWidget: *TappableImage does not implement fyne.Widget (missing method MinSize)
```