### PR TITLE
Change playing icon color for current track

### DIFF
--- a/ui/widgets/tracklist.go
+++ b/ui/widgets/tracklist.go
@@ -123,7 +123,11 @@ func NewTracklist(tracks []*mediaprovider.Track) *Tracklist {
 			t.OnColumnVisibilityMenuShown(pop)
 		}
 	}
-	playingIcon := container.NewCenter(container.NewHBox(util.NewHSpace(2), widget.NewIcon(theme.MediaPlayIcon())))
+
+	playIcon := theme.NewThemedResource(theme.MediaPlayIcon())
+	playIcon.ColorName = theme.ColorNamePrimary
+	playingIcon := container.NewCenter(container.NewHBox(util.NewHSpace(2), widget.NewIcon(playIcon)))
+
 	t.list = widget.NewList(
 		t.lenTracks,
 		func() fyne.CanvasObject {


### PR DESCRIPTION
Make the Play icon easier to spot within the playing queue, by using the primary color for the current theme.

Fixes #184

![image](https://github.com/dweymouth/supersonic/assets/3867850/77d13dc9-9fc7-4d1d-91ed-53f1cecd5197)
