### PR TITLE
Add MPRIS integration

### DIFF
--- a/backend/app.go
+++ b/backend/app.go
@@ -37,6 +37,7 @@ type App struct {
 	PlaybackManager *PlaybackManager
 	Player          *player.Player
 	UpdateChecker   UpdateChecker
+	MPRISHandler    *MPRISHandler
 	OnReactivate    func()
 
 	appName       string
@@ -102,6 +103,9 @@ func StartupApp(appName, appVersionTag, configFile, latestReleaseURL string) (*A
 	a.ServerManager.SetPrefetchAlbumCoverCallback(func(coverID string) {
 		_, _ = a.ImageManager.GetCoverThumbnail(coverID)
 	})
+
+	a.MPRISHandler = NewMPRISHandler(a.Player, a.PlaybackManager)
+	a.MPRISHandler.Start()
 
 	return a, nil
 }
@@ -221,6 +225,7 @@ func (a *App) DeleteServerCacheDir(serverID uuid.UUID) error {
 }
 
 func (a *App) Shutdown() {
+	a.MPRISHandler.Shutdown()
 	a.PlaybackManager.DisableCallbacks()
 	a.Player.Stop() // will trigger scrobble check
 	a.Config.LocalPlayback.Volume = a.Player.GetVolume()

--- a/backend/app.go
+++ b/backend/app.go
@@ -51,7 +51,7 @@ func (a *App) VersionTag() string {
 	return a.appVersionTag
 }
 
-func StartupApp(appName, appVersionTag, configFile, latestReleaseURL string) (*App, error) {
+func StartupApp(appName, displayAppName, appVersionTag, configFile, latestReleaseURL string) (*App, error) {
 	sessionPath := configdir.LocalConfig(appName, sessionDir)
 	if _, err := os.Stat(path.Join(sessionPath, sessionLockFile)); err == nil {
 		log.Println("Another instance is running. Reactivating it...")
@@ -104,7 +104,7 @@ func StartupApp(appName, appVersionTag, configFile, latestReleaseURL string) (*A
 		_, _ = a.ImageManager.GetCoverThumbnail(coverID)
 	})
 
-	a.MPRISHandler = NewMPRISHandler(a.Player, a.PlaybackManager)
+	a.MPRISHandler = NewMPRISHandler(displayAppName, a.Player, a.PlaybackManager)
 	a.MPRISHandler.Start()
 
 	return a, nil

--- a/backend/imagemanager.go
+++ b/backend/imagemanager.go
@@ -88,6 +88,16 @@ func (i *ImageManager) GetFullSizeCoverArt(coverID string) (image.Image, error) 
 	return im, nil
 }
 
+func (i *ImageManager) GetCoverArtUrl(coverID string) (string, error) {
+	path := i.filePathForCover(coverID)
+	if _, err := os.Stat(path); err == nil {
+		// this is probably broken for Windows but it's currently only used
+		// for MPRIS, so we are OK for now
+		return fmt.Sprintf("file://%s", path), nil
+	}
+	return "", errors.New("cover not found")
+}
+
 func (i *ImageManager) GetCachedArtistImage(artistID string) (image.Image, bool) {
 	return i.loadLocalImage(i.filePathForArtistImage(artistID))
 }

--- a/backend/mpris.go
+++ b/backend/mpris.go
@@ -48,6 +48,13 @@ func NewMPRISHandler(playerName string, p *player.Player, pm *PlaybackManager) *
 		pos := secondsToMicroseconds(m.p.GetStatus().TimePos)
 		m.evt.Player.OnSeek(pos)
 	})
+	m.pm.OnSongChange(func(_, _ *mediaprovider.Track) {
+		m.evt.Player.OnTitle()
+	})
+	emitPlayStatus := func() { m.evt.Player.OnPlayPause() }
+	m.p.OnStopped(emitPlayStatus)
+	m.p.OnPlaying(emitPlayStatus)
+	m.p.OnPaused(emitPlayStatus)
 	return m
 }
 

--- a/backend/mpris.go
+++ b/backend/mpris.go
@@ -15,8 +15,9 @@ import (
 const dbusTrackIDPrefix = "/Supersonic/Track/"
 
 var (
-	_ types.OrgMprisMediaPlayer2Adapter       = (*MPRISHandler)(nil)
-	_ types.OrgMprisMediaPlayer2PlayerAdapter = (*MPRISHandler)(nil)
+	_ types.OrgMprisMediaPlayer2Adapter                 = (*MPRISHandler)(nil)
+	_ types.OrgMprisMediaPlayer2PlayerAdapter           = (*MPRISHandler)(nil)
+	_ types.OrgMprisMediaPlayer2PlayerAdapterLoopStatus = (*MPRISHandler)(nil)
 )
 
 var (
@@ -184,6 +185,30 @@ func (m *MPRISHandler) PlaybackStatus() (types.PlaybackStatus, error) {
 		return types.PlaybackStatusStopped, nil
 	}
 	return "", errors.New("unknown playback status")
+}
+
+func (m *MPRISHandler) LoopStatus() (types.LoopStatus, error) {
+	switch m.pm.LoopMode() {
+	case LoopModeAll:
+		return types.LoopStatusPlaylist, nil
+	case LoopModeOne:
+		return types.LoopStatusTrack, nil
+	case LoopModeNone:
+		return types.LoopStatusNone, nil
+	}
+	return "", errors.New("unknown loop status")
+}
+
+func (m *MPRISHandler) SetLoopStatus(status types.LoopStatus) error {
+	switch status {
+	case types.LoopStatusPlaylist:
+		return m.pm.SetLoopMode(LoopModeAll)
+	case types.LoopStatusTrack:
+		return m.pm.SetLoopMode(LoopModeOne)
+	case types.LoopStatusNone:
+		return m.pm.SetLoopMode(LoopModeNone)
+	}
+	return errors.New("unknown loop status")
 }
 
 func (m *MPRISHandler) Rate() (float64, error) {

--- a/backend/mpris.go
+++ b/backend/mpris.go
@@ -44,17 +44,19 @@ func NewMPRISHandler(playerName string, p *player.Player, pm *PlaybackManager) *
 	m := &MPRISHandler{playerName: playerName, p: p, pm: pm}
 	m.s = server.NewServer(playerName, m, m)
 	m.evt = events.NewEventHandler(m.s)
-	m.p.OnSeek(func() {
-		pos := secondsToMicroseconds(m.p.GetStatus().TimePos)
-		m.evt.Player.OnSeek(pos)
-	})
-	m.pm.OnSongChange(func(_, _ *mediaprovider.Track) {
-		m.evt.Player.OnTitle()
-	})
-	emitPlayStatus := func() { m.evt.Player.OnPlayPause() }
-	m.p.OnStopped(emitPlayStatus)
-	m.p.OnPlaying(emitPlayStatus)
-	m.p.OnPaused(emitPlayStatus)
+	/*
+		m.p.OnSeek(func() {
+			pos := secondsToMicroseconds(m.p.GetStatus().TimePos)
+			m.evt.Player.OnSeek(pos)
+		})
+		m.pm.OnSongChange(func(_, _ *mediaprovider.Track) {
+			m.evt.Player.OnTitle()
+		})
+		emitPlayStatus := func() { m.evt.Player.OnPlayPause() }
+		m.p.OnStopped(emitPlayStatus)
+		m.p.OnPlaying(emitPlayStatus)
+		m.p.OnPaused(emitPlayStatus)
+	*/
 	return m
 }
 

--- a/backend/mpris.go
+++ b/backend/mpris.go
@@ -1,0 +1,172 @@
+package backend
+
+import (
+	"errors"
+
+	"github.com/dweymouth/supersonic/player"
+	"github.com/quarckster/go-mpris-server/pkg/events"
+	"github.com/quarckster/go-mpris-server/pkg/server"
+	"github.com/quarckster/go-mpris-server/pkg/types"
+)
+
+var (
+	_ types.OrgMprisMediaPlayer2Adapter       = (*MPRISHandler)(nil)
+	_ types.OrgMprisMediaPlayer2PlayerAdapter = (*MPRISHandler)(nil)
+)
+var (
+	notImplemented = errors.New("not implemented")
+)
+
+type MPRISHandler struct {
+	p   *player.Player
+	pm  *PlaybackManager
+	s   *server.Server
+	evt *events.EventHandler
+}
+
+func NewMPRISHandler(p *player.Player, pm *PlaybackManager) *MPRISHandler {
+	m := &MPRISHandler{p: p, pm: pm}
+	m.s = server.NewServer("Supersonic", m, m)
+	m.evt = events.NewEventHandler(m.s)
+	return m
+}
+
+func (m *MPRISHandler) Start() {
+	go m.s.Listen()
+}
+
+func (m *MPRISHandler) Shutdown() {
+	m.s.Stop()
+}
+
+// OrgMprisMediaPlayer2Adapter implementation
+
+func (m *MPRISHandler) Identity() (string, error) {
+	return "supersonic", nil
+}
+
+func (m *MPRISHandler) CanQuit() (bool, error) {
+	return false, nil
+}
+
+func (m *MPRISHandler) Quit() error {
+	return errors.New("not implemented")
+}
+
+func (m *MPRISHandler) CanRaise() (bool, error) {
+	return false, nil
+}
+
+func (m *MPRISHandler) Raise() error {
+	return errors.New("not implemented")
+}
+
+func (m *MPRISHandler) HasTrackList() (bool, error) {
+	return false, nil
+}
+
+func (m *MPRISHandler) SupportedUriSchemes() ([]string, error) {
+	return nil, nil
+}
+
+func (m *MPRISHandler) SupportedMimeTypes() ([]string, error) {
+	return nil, nil
+}
+
+// OrgMprisMediaPlayer2PlayerAdapter implementation
+
+func (m *MPRISHandler) Next() error {
+	return m.p.SeekNext()
+}
+
+func (m *MPRISHandler) Previous() error {
+	return m.p.SeekBackOrPrevious()
+}
+
+func (m *MPRISHandler) Pause() error {
+	return notImplemented
+}
+
+func (m *MPRISHandler) PlayPause() error {
+	return m.p.PlayPause()
+}
+
+func (m *MPRISHandler) Stop() error {
+	return notImplemented
+}
+
+func (m *MPRISHandler) Play() error {
+	return notImplemented
+}
+
+func (m *MPRISHandler) Seek(offset types.Microseconds) error {
+	return notImplemented
+}
+
+func (m *MPRISHandler) SetPosition(trackId string, position types.Microseconds) error {
+	return notImplemented
+}
+
+func (m *MPRISHandler) OpenUri(uri string) error {
+	return notImplemented
+}
+
+func (m *MPRISHandler) PlaybackStatus() (types.PlaybackStatus, error) {
+	return "", notImplemented
+}
+
+func (m *MPRISHandler) Rate() (float64, error) {
+	return 0, notImplemented
+}
+
+func (m *MPRISHandler) SetRate(float64) error {
+	return notImplemented
+}
+
+func (m *MPRISHandler) Metadata() (types.Metadata, error) {
+	return types.Metadata{}, notImplemented
+}
+
+func (m *MPRISHandler) Volume() (float64, error) {
+	return 0, notImplemented
+}
+
+func (m *MPRISHandler) SetVolume(float64) error {
+	return notImplemented
+}
+
+func (m *MPRISHandler) Position() (int64, error) {
+	return 0, notImplemented
+}
+
+func (m *MPRISHandler) MinimumRate() (float64, error) {
+	return 0, notImplemented
+}
+
+func (m *MPRISHandler) MaximumRate() (float64, error) {
+	return 0, notImplemented
+}
+
+func (m *MPRISHandler) CanGoNext() (bool, error) {
+	return false, notImplemented
+}
+
+func (m *MPRISHandler) CanGoPrevious() (bool, error) {
+	return false, notImplemented
+}
+
+func (m *MPRISHandler) CanPlay() (bool, error) {
+	return false, notImplemented
+}
+
+func (m *MPRISHandler) CanPause() (bool, error) {
+	return false, notImplemented
+}
+
+func (m *MPRISHandler) CanSeek() (bool, error) {
+	return false, notImplemented
+}
+
+func (m *MPRISHandler) CanControl() (bool, error) {
+	return false, notImplemented
+}

--- a/backend/mpris.go
+++ b/backend/mpris.go
@@ -59,6 +59,11 @@ func NewMPRISHandler(playerName string, p *player.Player, pm *PlaybackManager) *
 			m.evt.Player.OnTitle()
 		}
 	})
+	m.pm.OnVolumeChange(func(vol int) {
+		if m.connErr == nil {
+			m.evt.Player.OnVolume()
+		}
+	})
 	emitPlayStatus := func() {
 		if m.connErr == nil {
 			m.evt.Player.OnPlayPause()
@@ -253,8 +258,8 @@ func (m *MPRISHandler) Volume() (float64, error) {
 	return float64(m.p.GetVolume()) / 100, nil
 }
 
-func (m *MPRISHandler) SetVolume(float64) error {
-	return errNotImplemented
+func (m *MPRISHandler) SetVolume(v float64) error {
+	return m.pm.SetVolume(int(v * 100))
 }
 
 func (m *MPRISHandler) Position() (int64, error) {

--- a/backend/mpris.go
+++ b/backend/mpris.go
@@ -44,19 +44,21 @@ func NewMPRISHandler(playerName string, p *player.Player, pm *PlaybackManager) *
 	m := &MPRISHandler{playerName: playerName, p: p, pm: pm}
 	m.s = server.NewServer(playerName, m, m)
 	m.evt = events.NewEventHandler(m.s)
-	/*
-		m.p.OnSeek(func() {
-			pos := secondsToMicroseconds(m.p.GetStatus().TimePos)
-			m.evt.Player.OnSeek(pos)
-		})
-		m.pm.OnSongChange(func(_, _ *mediaprovider.Track) {
-			m.evt.Player.OnTitle()
-		})
-		emitPlayStatus := func() { m.evt.Player.OnPlayPause() }
-		m.p.OnStopped(emitPlayStatus)
-		m.p.OnPlaying(emitPlayStatus)
-		m.p.OnPaused(emitPlayStatus)
-	*/
+
+	m.p.OnSeek(func() {
+		pos := secondsToMicroseconds(m.p.GetStatus().TimePos)
+		m.evt.Player.OnSeek(pos)
+	})
+	m.pm.OnSongChange(func(_, _ *mediaprovider.Track) {
+		m.evt.Player.OnTitle()
+	})
+	emitPlayStatus := func() {
+		m.evt.Player.OnPlayPause()
+	}
+	m.p.OnStopped(emitPlayStatus)
+	m.p.OnPlaying(emitPlayStatus)
+	m.p.OnPaused(emitPlayStatus)
+
 	return m
 }
 
@@ -189,7 +191,7 @@ func (m *MPRISHandler) Metadata() (types.Metadata, error) {
 	}
 	var artURL string
 	if tr.ID != "" && m.ArtURLLookup != nil {
-		if u, err := m.ArtURLLookup(tr.ID); err == nil {
+		if u, err := m.ArtURLLookup(tr.CoverArtID); err == nil {
 			artURL = u
 		}
 	}

--- a/backend/playbackmanager.go
+++ b/backend/playbackmanager.go
@@ -17,6 +17,14 @@ const (
 	ReplayGainTrack = string(player.ReplayGainTrack)
 )
 
+type LoopMode int
+
+const (
+	LoopModeNone LoopMode = LoopMode(player.LoopNone)
+	LoopModeAll  LoopMode = LoopMode(player.LoopAll)
+	LoopModeOne  LoopMode = LoopMode(player.LoopOne)
+)
+
 // A high-level Subsonic-aware playback backend.
 // Manages loading tracks into the Player queue,
 // sending callbacks on play time updates and track changes.
@@ -40,7 +48,7 @@ type PlaybackManager struct {
 
 	onSongChange     []func(nowPlaying, justScrobbledIfAny *mediaprovider.Track)
 	onPlayTimeUpdate []func(float64, float64)
-	onLoopModeChange []func(string)
+	onLoopModeChange []func(LoopMode)
 }
 
 func NewPlaybackManager(
@@ -130,7 +138,7 @@ func (p *PlaybackManager) OnPlayTimeUpdate(cb func(float64, float64)) {
 }
 
 // Registers a callback that is notified whenever the loop mode changes.
-func (p *PlaybackManager) OnLoopModeChange(cb func(string)) {
+func (p *PlaybackManager) OnLoopModeChange(cb func(LoopMode)) {
 	p.onLoopModeChange = append(p.onLoopModeChange, cb)
 }
 
@@ -305,10 +313,26 @@ func (p *PlaybackManager) SetNextLoopMode() error {
 	}
 
 	for _, cb := range p.onLoopModeChange {
-		cb(p.player.GetLoopMode().String())
+		cb(LoopMode(p.player.GetLoopMode()))
 	}
 
 	return nil
+}
+
+func (p *PlaybackManager) SetLoopMode(loopMode LoopMode) error {
+	if err := p.player.SetLoopMode(player.LoopMode(loopMode)); err != nil {
+		return err
+	}
+
+	for _, cb := range p.onLoopModeChange {
+		cb(loopMode)
+	}
+
+	return nil
+}
+
+func (p *PlaybackManager) LoopMode() LoopMode {
+	return LoopMode(p.player.GetLoopMode())
 }
 
 // call BEFORE updating p.nowPlayingIdx

--- a/go.mod
+++ b/go.mod
@@ -48,3 +48,5 @@ require (
 )
 
 replace fyne.io/fyne/v2 v2.3.5 => github.com/dweymouth/fyne/v2 v2.3.0-rc1.0.20230505012127-ca61c153b2a5
+
+replace github.com/quarckster/go-mpris-server v1.0.1 => github.com/dweymouth/go-mpris-server v0.0.0-20230714011337-8bc0b52618a5

--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,7 @@ require (
 	github.com/jsummers/gobmp v0.0.0-20151104160322-e2ba15ffa76e // indirect
 	github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/quarckster/go-mpris-server v1.0.0 // indirect
 	github.com/srwiley/oksvg v0.0.0-20220731023508-a61f04f16b76 // indirect
 	github.com/srwiley/rasterx v0.0.0-20210519020934-456a8d69b780 // indirect
 	github.com/stretchr/testify v1.8.3 // indirect

--- a/go.mod
+++ b/go.mod
@@ -9,8 +9,10 @@ require (
 	github.com/dweymouth/go-mpv v0.0.0-20230406003141-7f1858e503ee
 	github.com/dweymouth/go-subsonic v0.0.0-20230614154319-792d18c75fb4
 	github.com/fsnotify/fsnotify v1.6.0
+	github.com/godbus/dbus/v5 v5.1.0
 	github.com/google/uuid v1.3.0
 	github.com/pelletier/go-toml/v2 v2.0.8
+	github.com/quarckster/go-mpris-server v1.0.1
 	github.com/zalando/go-keyring v0.2.1
 	golang.org/x/net v0.0.0-20220722155237-a158d28d115b
 )
@@ -27,13 +29,11 @@ require (
 	github.com/go-gl/gl v0.0.0-20211210172815-726fda9656d6 // indirect
 	github.com/go-gl/glfw/v3.3/glfw v0.0.0-20221017161538-93cebf72946b // indirect
 	github.com/go-text/typesetting v0.0.0-20230405155246-bf9c697c6e16 // indirect
-	github.com/godbus/dbus/v5 v5.1.0 // indirect
 	github.com/goki/freetype v0.0.0-20220119013949-7a161fd3728c // indirect
 	github.com/gopherjs/gopherjs v1.17.2 // indirect
 	github.com/jsummers/gobmp v0.0.0-20151104160322-e2ba15ffa76e // indirect
 	github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/quarckster/go-mpris-server v1.0.0 // indirect
 	github.com/srwiley/oksvg v0.0.0-20220731023508-a61f04f16b76 // indirect
 	github.com/srwiley/rasterx v0.0.0-20210519020934-456a8d69b780 // indirect
 	github.com/stretchr/testify v1.8.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -76,6 +76,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dweymouth/fyne/v2 v2.3.0-rc1.0.20230505012127-ca61c153b2a5 h1:uXbHzg9HfefA7OVHu9gahobCP5B43df3L1MwU0GbdRs=
 github.com/dweymouth/fyne/v2 v2.3.0-rc1.0.20230505012127-ca61c153b2a5/go.mod h1:X2+NrR+62mvAiAt2fwKT7035zQsE77KVV1NlvWo4vW8=
+github.com/dweymouth/go-mpris-server v0.0.0-20230714011337-8bc0b52618a5 h1:QhBf0iHPPUSxalHjhls+9LFqMuNT12U3Mo/AFw4Ornc=
+github.com/dweymouth/go-mpris-server v0.0.0-20230714011337-8bc0b52618a5/go.mod h1:2b4IdrpnEoEfU+6fQKjYhAgdvsiz4JxmTpDAUrMJVO4=
 github.com/dweymouth/go-mpv v0.0.0-20230406003141-7f1858e503ee h1:ZGyJ6wp7CAfT31BugypcF/TPKEy2RrGR9JFq1JOjOpY=
 github.com/dweymouth/go-mpv v0.0.0-20230406003141-7f1858e503ee/go.mod h1:Ov0ieN90M7i+0k3OxhA/g1dozGs+UcPHDsMKqPgRDk0=
 github.com/dweymouth/go-subsonic v0.0.0-20230614154319-792d18c75fb4 h1:cuyvB4GjTMBHKJwMJ/LFpuKfSVXuCheNj6fgxBa3m1Y=
@@ -265,8 +267,6 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
-github.com/quarckster/go-mpris-server v1.0.1 h1:JAbVBJK1ijjwEH4gfaOtwfElDVuaBPnWyi8rZJEHOxc=
-github.com/quarckster/go-mpris-server v1.0.1/go.mod h1:2b4IdrpnEoEfU+6fQKjYhAgdvsiz4JxmTpDAUrMJVO4=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=

--- a/go.sum
+++ b/go.sum
@@ -265,6 +265,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
+github.com/quarckster/go-mpris-server v1.0.0 h1:9EKh8Ink7d3OigBLXGlRJ0jDJi+O6T/XMroA5Gl4c5Q=
+github.com/quarckster/go-mpris-server v1.0.0/go.mod h1:2b4IdrpnEoEfU+6fQKjYhAgdvsiz4JxmTpDAUrMJVO4=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=

--- a/go.sum
+++ b/go.sum
@@ -265,8 +265,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
-github.com/quarckster/go-mpris-server v1.0.0 h1:9EKh8Ink7d3OigBLXGlRJ0jDJi+O6T/XMroA5Gl4c5Q=
-github.com/quarckster/go-mpris-server v1.0.0/go.mod h1:2b4IdrpnEoEfU+6fQKjYhAgdvsiz4JxmTpDAUrMJVO4=
+github.com/quarckster/go-mpris-server v1.0.1 h1:JAbVBJK1ijjwEH4gfaOtwfElDVuaBPnWyi8rZJEHOxc=
+github.com/quarckster/go-mpris-server v1.0.1/go.mod h1:2b4IdrpnEoEfU+6fQKjYhAgdvsiz4JxmTpDAUrMJVO4=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=

--- a/main.go
+++ b/main.go
@@ -23,7 +23,7 @@ const (
 )
 
 func main() {
-	myApp, err := backend.StartupApp(appname, appVersionTag, configFile, latestReleaseURL)
+	myApp, err := backend.StartupApp(appname, displayName, appVersionTag, configFile, latestReleaseURL)
 	if err != nil {
 		log.Fatalf("fatal startup error: %v", err.Error())
 	}

--- a/main.go
+++ b/main.go
@@ -41,6 +41,10 @@ func main() {
 	}
 	mainWindow := ui.NewMainWindow(fyneApp, appname, displayName, appVersion, myApp, fyne.NewSize(w, h))
 	myApp.OnReactivate = mainWindow.Show
+	myApp.OnExit = func() {
+		saveWindowPosition(myApp.Config, mainWindow.Window)
+		fyneApp.Quit()
+	}
 
 	go func() {
 		// TODO: There is a race condition with laying out the window before the
@@ -61,8 +65,7 @@ func main() {
 
 	mainWindow.Show()
 	mainWindow.Window.SetCloseIntercept(func() {
-		myApp.Config.Application.WindowHeight = int(mainWindow.Canvas().Size().Height)
-		myApp.Config.Application.WindowWidth = int(mainWindow.Canvas().Size().Width)
+		saveWindowPosition(myApp.Config, mainWindow.Window)
 		if myApp.Config.Application.CloseToSystemTray &&
 			mainWindow.HaveSystemTray() {
 			mainWindow.Window.Hide()
@@ -74,4 +77,9 @@ func main() {
 
 	log.Println("Running shutdown tasks...")
 	myApp.Shutdown()
+}
+
+func saveWindowPosition(config *backend.Config, window fyne.Window) {
+	config.Application.WindowHeight = int(window.Canvas().Size().Height)
+	config.Application.WindowWidth = int(window.Canvas().Size().Width)
 }

--- a/ui/bottompanel.go
+++ b/ui/bottompanel.go
@@ -54,9 +54,7 @@ func NewBottomPanel(p *player.Player, pm *backend.PlaybackManager, contr *contro
 	p.OnStopped(func() {
 		bp.Controls.SetPlaying(false)
 	})
-	pm.OnLoopModeChange(func(mode backend.LoopMode) {
-		bp.AuxControls.SetLoopMode(mode)
-	})
+	pm.OnLoopModeChange(bp.AuxControls.SetLoopMode)
 
 	bp.NowPlaying = widgets.NewNowPlayingCard()
 	bp.NowPlaying.OnShowCoverImage = func() {
@@ -100,8 +98,9 @@ func NewBottomPanel(p *player.Player, pm *backend.PlaybackManager, contr *contro
 	})
 
 	bp.AuxControls = widgets.NewAuxControls(p.GetVolume())
-	bp.AuxControls.VolumeControl.OnVolumeChanged = func(v int) {
-		_ = p.SetVolume(v)
+	pm.OnVolumeChange(bp.AuxControls.VolumeControl.SetVolume)
+	bp.AuxControls.VolumeControl.OnSetVolume = func(v int) {
+		_ = bp.playbackManager.SetVolume(v)
 	}
 	bp.AuxControls.OnChangeLoopMode(func() {
 		bp.playbackManager.SetNextLoopMode()

--- a/ui/bottompanel.go
+++ b/ui/bottompanel.go
@@ -54,7 +54,6 @@ func NewBottomPanel(p *player.Player, pm *backend.PlaybackManager, contr *contro
 	p.OnStopped(func() {
 		bp.Controls.SetPlaying(false)
 	})
-	pm.OnLoopModeChange(bp.AuxControls.SetLoopMode)
 
 	bp.NowPlaying = widgets.NewNowPlayingCard()
 	bp.NowPlaying.OnShowCoverImage = func() {
@@ -98,6 +97,7 @@ func NewBottomPanel(p *player.Player, pm *backend.PlaybackManager, contr *contro
 	})
 
 	bp.AuxControls = widgets.NewAuxControls(p.GetVolume())
+	pm.OnLoopModeChange(bp.AuxControls.SetLoopMode)
 	pm.OnVolumeChange(bp.AuxControls.VolumeControl.SetVolume)
 	bp.AuxControls.VolumeControl.OnSetVolume = func(v int) {
 		_ = bp.playbackManager.SetVolume(v)

--- a/ui/bottompanel.go
+++ b/ui/bottompanel.go
@@ -54,7 +54,7 @@ func NewBottomPanel(p *player.Player, pm *backend.PlaybackManager, contr *contro
 	p.OnStopped(func() {
 		bp.Controls.SetPlaying(false)
 	})
-	pm.OnLoopModeChange(func(mode string) {
+	pm.OnLoopModeChange(func(mode backend.LoopMode) {
 		bp.AuxControls.SetLoopMode(mode)
 	})
 

--- a/ui/mainwindow.go
+++ b/ui/mainwindow.go
@@ -163,15 +163,15 @@ func (m *MainWindow) SetupSystemTrayMenu(appName string, fyneApp fyne.App) {
 			}),
 			fyne.NewMenuItemSeparator(),
 			fyne.NewMenuItem("Volume +10%", func() {
-				vol := m.App.Player.GetVolume()
+				vol := m.App.PlaybackManager.Volume()
 				vol = vol + int(float64(vol)*0.1)
 				// will clamp to range for us
-				m.BottomPanel.AuxControls.VolumeControl.SetVolume(vol)
+				m.App.PlaybackManager.SetVolume(vol)
 			}),
 			fyne.NewMenuItem("Volume -10%", func() {
-				vol := m.App.Player.GetVolume()
+				vol := m.App.PlaybackManager.Volume()
 				vol = vol - int(float64(vol)*0.1)
-				m.BottomPanel.AuxControls.VolumeControl.SetVolume(vol)
+				m.App.PlaybackManager.SetVolume(vol)
 			}),
 			fyne.NewMenuItemSeparator(),
 			fyne.NewMenuItem("Show", m.Window.Show),

--- a/ui/widgets/auxcontrols.go
+++ b/ui/widgets/auxcontrols.go
@@ -162,7 +162,7 @@ type VolumeControl struct {
 	icon   *TappableIcon
 	slider *volumeSlider
 
-	OnVolumeChanged func(int)
+	OnSetVolume func(int)
 
 	muted   bool
 	lastVol int
@@ -185,24 +185,35 @@ func NewVolumeControl(initialVol int) *VolumeControl {
 	return v
 }
 
+// Sets the volume that is displayed in the slider.
+// Does not invoke OnSetVolume callback.
+func (v *VolumeControl) SetVolume(vol int) {
+	if (vol == v.lastVol && !v.muted) || (v.muted && vol == 0) {
+		return
+	}
+	v.lastVol = vol
+	v.muted = false
+	v.setDisplayedVolume(vol)
+}
+
 func (v *VolumeControl) onChanged(volume float64) {
 	vol := int(volume)
 	v.lastVol = vol
 	v.muted = false
 	v.updateIconForVolume(vol)
-	if v.OnVolumeChanged != nil {
-		v.OnVolumeChanged(vol)
-	}
+	v.invokeOnVolumeChange(vol)
 }
 
 func (v *VolumeControl) toggleMute() {
 	if !v.muted {
 		v.muted = true
 		v.lastVol = int(v.slider.Value)
-		v.SetVolume(0)
+		v.setDisplayedVolume(0)
+		v.invokeOnVolumeChange(0)
 	} else {
 		v.muted = false
-		v.SetVolume(v.lastVol)
+		v.setDisplayedVolume(v.lastVol)
+		v.invokeOnVolumeChange(v.lastVol)
 	}
 }
 
@@ -211,12 +222,15 @@ func (v *VolumeControl) CreateRenderer() fyne.WidgetRenderer {
 	return widget.NewSimpleRenderer(v.container)
 }
 
-func (v *VolumeControl) SetVolume(vol int) {
+func (v *VolumeControl) setDisplayedVolume(vol int) {
 	v.slider.Value = float64(vol)
 	v.slider.Refresh()
 	v.updateIconForVolume(vol)
-	if v.OnVolumeChanged != nil {
-		v.OnVolumeChanged(vol)
+}
+
+func (v *VolumeControl) invokeOnVolumeChange(vol int) {
+	if v.OnSetVolume != nil {
+		v.OnSetVolume(vol)
 	}
 }
 

--- a/ui/widgets/auxcontrols.go
+++ b/ui/widgets/auxcontrols.go
@@ -7,6 +7,7 @@ import (
 	"fyne.io/fyne/v2/theme"
 	"fyne.io/fyne/v2/widget"
 
+	"github.com/dweymouth/supersonic/backend"
 	myTheme "github.com/dweymouth/supersonic/ui/theme"
 	"github.com/dweymouth/supersonic/ui/util"
 )
@@ -67,14 +68,15 @@ func (a *AuxControls) OnChangeLoopMode(f func()) {
 	a.loop.OnTapped = f
 }
 
-func (a *AuxControls) SetLoopMode(mode string) {
-	if mode == "all" {
+func (a *AuxControls) SetLoopMode(mode backend.LoopMode) {
+	switch mode {
+	case backend.LoopModeAll:
 		a.loop.Importance = widget.HighImportance
 		a.loop.Icon = myTheme.RepeatIcon
-	} else if mode == "one" {
+	case backend.LoopModeOne:
 		a.loop.Importance = widget.HighImportance
 		a.loop.Icon = myTheme.RepeatOneIcon
-	} else {
+	case backend.LoopModeNone:
 		a.loop.Importance = widget.MediumImportance
 		a.loop.Icon = myTheme.RepeatIcon
 	}


### PR DESCRIPTION
Fixes: #75 
Related: #56 

This adds MPRIS support, which allows responding to media keys on Linux, remote control by `playerctl` and other tools, and integration with the now playing center in various desktop shells.