### PR TITLE
Extends MacOS MPMedia implementation to support 'seek' & 'duration'

### DIFF
--- a/backend/mpmedia_mac.go
+++ b/backend/mpmedia_mac.go
@@ -27,7 +27,7 @@ import (
 // os_remote_command_callback is called by Objective-C when incoming OS media commands are received.
 //
 //export os_remote_command_callback
-func os_remote_command_callback(command C.Command, value C.int) {
+func os_remote_command_callback(command C.Command, value C.double) {
 	switch command {
 	case C.PLAY:
 		mpMediaEventRecipient.OnCommandPlay()
@@ -42,7 +42,7 @@ func os_remote_command_callback(command C.Command, value C.int) {
 	case C.NEXT_TRACK:
 		mpMediaEventRecipient.OnCommandNextTrack()
 	case C.SEEK:
-		mpMediaEventRecipient.OnCommandSeek(int(value))
+		mpMediaEventRecipient.OnCommandSeek(float64(value))
 	default:
 		log.Printf("unknown OS command received: %v", command)
 	}
@@ -172,9 +172,9 @@ func (mp *MPMediaHandler) OnCommandPreviousTrack() {
 }
 
 // MPMediaHandler instance received OS command to 'seek'
-func (mp *MPMediaHandler) OnCommandSeek(positionSeconds int) {
+func (mp *MPMediaHandler) OnCommandSeek(positionSeconds float64) {
 	if mp == nil || mp.player == nil {
 		return
 	}
-	mp.player.Seek(fmt.Sprintf("%d", positionSeconds), player.SeekAbsolute)
+	mp.player.Seek(fmt.Sprintf("%0.2f", positionSeconds), player.SeekAbsolute)
 }

--- a/backend/mpmedia_mac.go
+++ b/backend/mpmedia_mac.go
@@ -98,15 +98,17 @@ func NewMPMediaHandler(player *player.Player, playbackManager *PlaybackManager) 
 		C.set_os_playback_state_stopped()
 	})
 
+	mp.player.OnSeek(func() {
+		C.update_os_now_playing_info_position(C.double(mp.player.GetStatus().TimePos))
+	})
+
 	mp.player.OnPlaying(func() {
 		C.set_os_playback_state_playing()
+		C.update_os_now_playing_info_position(C.double(mp.player.GetStatus().TimePos))
 	})
 
 	mp.player.OnPaused(func() {
 		C.set_os_playback_state_paused()
-	})
-
-	mp.player.OnSeek(func() {
 		C.update_os_now_playing_info_position(C.double(mp.player.GetStatus().TimePos))
 	})
 

--- a/backend/mpmediabridge.h
+++ b/backend/mpmediabridge.h
@@ -20,7 +20,8 @@ typedef enum {
     STOP,
     TOGGLE,
     NEXT_TRACK,
-    PREVIOUS_TRACK
+    PREVIOUS_TRACK,
+    SEEK
 } Command;
 
 /**
@@ -30,15 +31,17 @@ void register_os_remote_commands();
 
 /**
 * Go-backed callback to static function that is called when OS remote commands are received.
+* If a value is anticipated with the specified command, the 'value' argument will be non-zero.
 */
-void os_remote_command_callback(Command command);
+void os_remote_command_callback(Command command, int value);
 
 /**
  * Updates the "Now Playing" information on macOS for media playback
  * using the MPNowPlayingInfoCenter API to set the metadata 
  * for the currently playing media in the system's "Now Playing" interface.
  */
-void set_os_now_playing_info(const char *title, const char *artist, const char *coverArtFileURL);
+void set_os_now_playing_info(const char *title, const char *artist, const char *coverArtFileURL, double trackDuration);
+void update_os_now_playing_info_position(double positionSeconds);
 
 /**
  * Setter functions for updating the global playback state.

--- a/backend/mpmediabridge.h
+++ b/backend/mpmediabridge.h
@@ -33,7 +33,7 @@ void register_os_remote_commands();
 * Go-backed callback to static function that is called when OS remote commands are received.
 * If a value is anticipated with the specified command, the 'value' argument will be non-zero.
 */
-void os_remote_command_callback(Command command, int value);
+void os_remote_command_callback(Command command, double value);
 
 /**
  * Updates the "Now Playing" information on macOS for media playback

--- a/backend/mpmediabridge.m
+++ b/backend/mpmediabridge.m
@@ -63,6 +63,7 @@ void set_os_now_playing_info(const char *title, const char *artist, const char *
         MPMediaItemPropertyTitle: [NSString stringWithUTF8String:title],
         MPMediaItemPropertyArtist: [NSString stringWithUTF8String:artist],
         MPMediaItemPropertyArtwork: coverArt,
+        MPNowPlayingInfoPropertyElapsedPlaybackTime: @(0),
         MPMediaItemPropertyPlaybackDuration: @(trackDuration) // Expects 'NSNumber'
     };
     

--- a/backend/mpmediabridge.m
+++ b/backend/mpmediabridge.m
@@ -39,9 +39,7 @@ void register_os_remote_commands() {
 
     [commandCenter.changePlaybackPositionCommand addTargetWithHandler:^MPRemoteCommandHandlerStatus(MPRemoteCommandEvent * _Nonnull event) {
         MPChangePlaybackPositionCommandEvent *positionChangeEvent = (MPChangePlaybackPositionCommandEvent *)event;
-        double posSecDouble = positionChangeEvent.positionTime;
-        int posSeconds = (int)posSecDouble; 
-        os_remote_command_callback(SEEK, posSeconds);
+        os_remote_command_callback(SEEK, positionChangeEvent.positionTime);
         return MPRemoteCommandHandlerStatusSuccess;
     }];
 }

--- a/backend/mpmediabridge.m
+++ b/backend/mpmediabridge.m
@@ -8,32 +8,40 @@
 void register_os_remote_commands() {
     MPRemoteCommandCenter *commandCenter = [MPRemoteCommandCenter sharedCommandCenter];
     [commandCenter.playCommand addTargetWithHandler:^MPRemoteCommandHandlerStatus(MPRemoteCommandEvent * _Nonnull event) {
-        os_remote_command_callback(PLAY);
+        os_remote_command_callback(PLAY, 0);
         return MPRemoteCommandHandlerStatusSuccess;
     }];
 
     [commandCenter.pauseCommand addTargetWithHandler:^MPRemoteCommandHandlerStatus(MPRemoteCommandEvent * _Nonnull event) {
-        os_remote_command_callback(PAUSE);
+        os_remote_command_callback(PAUSE, 0);
         return MPRemoteCommandHandlerStatusSuccess;
     }];
 
     [commandCenter.togglePlayPauseCommand addTargetWithHandler:^MPRemoteCommandHandlerStatus(MPRemoteCommandEvent * _Nonnull event) {
-        os_remote_command_callback(TOGGLE);
+        os_remote_command_callback(TOGGLE, 0);
         return MPRemoteCommandHandlerStatusSuccess;
     }];
 
     [commandCenter.stopCommand addTargetWithHandler:^MPRemoteCommandHandlerStatus(MPRemoteCommandEvent * _Nonnull event) {
-        os_remote_command_callback(STOP);
+        os_remote_command_callback(STOP, 0);
         return MPRemoteCommandHandlerStatusSuccess;
     }];
 
     [commandCenter.nextTrackCommand addTargetWithHandler:^MPRemoteCommandHandlerStatus(MPRemoteCommandEvent * _Nonnull event) {
-        os_remote_command_callback(NEXT_TRACK);
+        os_remote_command_callback(NEXT_TRACK, 0);
         return MPRemoteCommandHandlerStatusSuccess;
     }];
 
     [commandCenter.previousTrackCommand addTargetWithHandler:^MPRemoteCommandHandlerStatus(MPRemoteCommandEvent * _Nonnull event) {
-        os_remote_command_callback(PREVIOUS_TRACK);
+        os_remote_command_callback(PREVIOUS_TRACK, 0);
+        return MPRemoteCommandHandlerStatusSuccess;
+    }];
+
+    [commandCenter.changePlaybackPositionCommand addTargetWithHandler:^MPRemoteCommandHandlerStatus(MPRemoteCommandEvent * _Nonnull event) {
+        MPChangePlaybackPositionCommandEvent *positionChangeEvent = (MPChangePlaybackPositionCommandEvent *)event;
+        double posSecDouble = positionChangeEvent.positionTime;
+        int posSeconds = (int)posSecDouble; 
+        os_remote_command_callback(SEEK, posSeconds);
         return MPRemoteCommandHandlerStatusSuccess;
     }];
 }
@@ -41,7 +49,7 @@ void register_os_remote_commands() {
 /**
  * C bridge setting "Now Playing" information on macOS for media playback using the native APIs.
  */
-void set_os_now_playing_info(const char *title, const char *artist, const char *coverArtFileURL) {
+void set_os_now_playing_info(const char *title, const char *artist, const char *coverArtFileURL, double trackDuration) {
     NSString *coverArtLocationString = [NSString stringWithUTF8String:coverArtFileURL];
     NSURL *coverArtURL = [NSURL URLWithString:coverArtLocationString];
     NSImage *coverArtImage = [[NSImage alloc] initWithContentsOfURL:coverArtURL];
@@ -54,10 +62,22 @@ void set_os_now_playing_info(const char *title, const char *artist, const char *
     NSDictionary *nowPlayingInfo = @{
         MPMediaItemPropertyTitle: [NSString stringWithUTF8String:title],
         MPMediaItemPropertyArtist: [NSString stringWithUTF8String:artist],
-        MPMediaItemPropertyArtwork: coverArt 
+        MPMediaItemPropertyArtwork: coverArt,
+        MPMediaItemPropertyPlaybackDuration: @(trackDuration) // Expects 'NSNumber'
     };
     
     infoCenter.nowPlayingInfo = nowPlayingInfo;
+}
+
+/**
+ * C bridge updating the OS playback position.
+ * creates a mutable copy of the immutable dictionary and writes it back with updated position.
+ */
+void update_os_now_playing_info_position(double positionSeconds) {
+    MPNowPlayingInfoCenter *infoCenter = [MPNowPlayingInfoCenter defaultCenter];
+    NSMutableDictionary *updatedInfo = [infoCenter.nowPlayingInfo mutableCopy];
+    updatedInfo[MPNowPlayingInfoPropertyElapsedPlaybackTime] = @(positionSeconds);
+    infoCenter.nowPlayingInfo = [updatedInfo copy];
 }
 
 /**


### PR DESCRIPTION
## Overview:

Extends the recently merged MacOS 'MPMedia' implementation to support OS 'seek' and 'duration' display.
The 'full' MacOS music widget now displays track length and allows seeking of track position.

- Supersonic responds to track position changes when the track position is changed via the OS slider
- OS slider responds to track position changes when the track position is changed via Supersonic.

<img width="309" alt="screen" src="https://github.com/dweymouth/supersonic/assets/2040617/58cd865f-d2f1-4387-8b60-a26959caa307">

## Reasoning:

Feature discussed in previous PR.

## Additional notes:

Extending the the initial implementation to support this was simpler than I initially anticipated, so here's the additional Pull Request.
