### PR TITLE
fix: Avoid crash when removing last track from queue

### DIFF
--- a/backend/playbackmanager.go
+++ b/backend/playbackmanager.go
@@ -121,7 +121,7 @@ func (p *PlaybackManager) DisableCallbacks() {
 
 // Gets the curently playing song, if any.
 func (p *PlaybackManager) NowPlaying() *mediaprovider.Track {
-	if len(p.playQueue) == 0 || p.player.GetStatus().State == player.Stopped {
+	if len(p.playQueue) == 0 || p.nowPlayingIdx < 0 || p.player.GetStatus().State == player.Stopped {
 		return nil
 	}
 	return p.playQueue[p.nowPlayingIdx]

--- a/ui/browsing/nowplayingpage.go
+++ b/ui/browsing/nowplayingpage.go
@@ -203,6 +203,7 @@ func (a *NowPlayingPage) load(highlightedTrackID string) {
 	a.queue = a.pm.GetPlayQueue()
 	a.tracklist.SetTracks(a.queue)
 	a.tracklist.SetNowPlaying(a.nowPlayingID)
+	a.tracklist.Refresh()
 	if highlightedTrackID != "" {
 		a.tracklist.SelectAndScrollToTrack(highlightedTrackID)
 	}


### PR DESCRIPTION
### Steps to reproduce

1. Put multiple tracks in the queue (visible in the "Now Playing" panel).
2. Start reproducing **any** track in the queue.
3. Select tracks from the one being reproduced until the end of the queue (this was also reproducible when the last track is playing, and only that one is selected in this step).
4. Select the "Remove from queue" option.

### Expected

1. Selected tracks are removed from the queue.
2. Player is now in Stopped state.
3. If there are more tracks in the queue (not all of them were selected to be removed in step 3), then clicking on the "Play" button starts reproducing the queue from the beginning.

### Actual

Currently, the app crashes when step 4 is applied.

Fixes #270.