### PR TITLE
Check if server is nil before passing pointer to go-keyring

### DIFF
--- a/backend/servermanager.go
+++ b/backend/servermanager.go
@@ -28,7 +28,10 @@ type ServerManager struct {
 	onLogout          []func()
 }
 
-var ErrUnreachable = errors.New("server is unreachable")
+var (
+	ErrUnreachable = errors.New("server is unreachable")
+	ErrNilServer   = errors.New("nil server provided")
+)
 
 func NewServerManager(appName string, config *Config) *ServerManager {
 	return &ServerManager{appName: appName, config: config}
@@ -156,6 +159,9 @@ func (s *ServerManager) GetServerPassword(serverID uuid.UUID) (string, error) {
 }
 
 func (s *ServerManager) SetServerPassword(server *ServerConfig, password string) error {
+	if server == nil {
+		return ErrNilServer
+	}
 	return keyring.Set(s.appName, server.ID.String(), password)
 }
 


### PR DESCRIPTION
I'm running into an issue that appears to be related to https://github.com/zalando/go-keyring/issues/88, which I describe in https://github.com/zalando/go-keyring/issues/88#issuecomment-1914505694. The gist of the issue is that an incompatibility between go-keyring and KeepassXC causes a segfault in the `SetServerPassword` method as the `ServerConfig` isn't properly initialized.

```
2024/01/29 03:11:41 error getting password from keyring: org.freedesktop.Secret.Error.IsLocked
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x28 pc=0x5e33a2]

goroutine 79 [running]:
github.com/zalando/go-keyring/secret_service.(*SecretService).handlePrompt(0xc0091ef050, {0xc000462380?, 0x2c?})
	github.com/zalando/go-keyring@v0.2.1/secret_service/secret_service.go:197 +0x122
github.com/zalando/go-keyring/secret_service.(*SecretService).CreateItem(0xd69990?, {0xe6cdb0, 0xc0089842d0}, {0xc009084780, 0x43}, 0xc00a337620, {{0xc008e7d1d0, 0x41}, {0x1b1af00, 0x0, ...}, ...})
	github.com/zalando/go-keyring@v0.2.1/secret_service/secret_service.go:175 +0x370
github.com/zalando/go-keyring.secretServiceProvider.Set({}, {0xd1127f, 0xa}, {0xc0089b61b0, 0x24}, {0xc008402c80, 0x40})
	github.com/zalando/go-keyring@v0.2.1/keyring_unix.go:43 +0x3be
github.com/zalando/go-keyring.Set(...)
	github.com/zalando/go-keyring@v0.2.1/keyring.go:27
github.com/dweymouth/supersonic/backend.(*ServerManager).SetServerPassword(0xc0000fb900, 0xc008813eb0?, {0xc008402c80, 0x40})
	github.com/dweymouth/supersonic/backend/servermanager.go:159 +0xb6
github.com/dweymouth/supersonic/ui/controller.(*Controller).trySetPasswordAndConnectToServer(0xc000582300, 0x8?, {0xc008402c80, 0x40})
	github.com/dweymouth/supersonic/ui/controller/controller.go:544 +0x3c
github.com/dweymouth/supersonic/ui/controller.(*Controller).PromptForLoginAndConnect.func1.1()
	github.com/dweymouth/supersonic/ui/controller/controller.go:376 +0x178
created by github.com/dweymouth/supersonic/ui/controller.(*Controller).PromptForLoginAndConnect.func1 in goroutine 84
	github.com/dweymouth/supersonic/ui/controller/controller.go:368 +0x105
```

As there's currently no ETA for the upstream issue being fixed, I propose the following solution to prevent a segfault in the event that this or any other issue crops up which causes the `ServerConfig` to be `nil`. Since [`trySetPasswordAndConnectToServer()`](https://github.com/dweymouth/supersonic/blob/main/ui/controller/controller.go#L559C22-L566) can gracefully handle an error in `SetServerPassword()`, this seems like it should be a safe fix since we can just store the password in-memory.