### PR TITLE
add developer_name to appstream data file

### DIFF
--- a/res/io.github.dweymouth.supersonic.appdata.xml
+++ b/res/io.github.dweymouth.supersonic.appdata.xml
@@ -5,6 +5,7 @@
   <metadata_license>FSFAP</metadata_license>
   <project_license>GPL-3.0+</project_license>
   <name>Supersonic</name>
+  <developer_name>Drew Weymouth</developer_name>
   <summary> A lightweight cross-platform desktop client for Subsonic and Jellyfin music servers</summary>
   <content_rating type="oars-1.0">
     <content_attribute id="social-audio">intense</content_attribute>


### PR DESCRIPTION
It seems this is necessary in Flatpaks now. I have a build that failed with:

```
flatpak run --command=flatpak-builder-lint org.flatpak.Builder --exceptions repo repo
 in dir /srv/buildbot/worker/build-x86_64-1/build (timeout 1200 secs)
 watching logfiles {}
 argv: b'flatpak run --command=flatpak-builder-lint org.flatpak.Builder --exceptions repo repo'
 using PTY: False
{
    "errors": [
        "appstream-missing-developer-name"
    ],
    "warnings": [
        "appstream-summary-too-long",
        "appstream-screenshot-missing-caption"
    ]
}
Please consult the documentation at https://docs.flathub.org/docs/for-app-authors/linter
program finished with exit code 1
elapsedTime=54.274905
```

... interestingly, that is marked as "warning" in the above documentation:

https://docs.flathub.org/docs/for-app-authors/linter/#appstream-missing-developer-name

... but is reported as an error now. Even worse, the tag is deprecated:

https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-developer_name

I tried to fix it by vendoring this fixed version in the flatpak, we'll see how that goes:

https://github.com/flathub/io.github.dweymouth.supersonic/pull/62#issuecomment-1916007362