### PR TITLE
fix: MPRIS Seek functionality on Linux

### DIFF
--- a/backend/mpris.go
+++ b/backend/mpris.go
@@ -59,13 +59,13 @@ func NewMPRISHandler(playerName string, pm *PlaybackManager) *MPRISHandler {
 		}
 	})
 	pm.OnSongChange(func(tr, _ *mediaprovider.Track) {
-		if m.connErr == nil {
-			m.evt.Player.OnTitle()
-		}
 		if tr == nil {
 			m.curTrackPath = ""
 		} else {
 			m.curTrackPath = dbusTrackIDPrefix + encodeTrackId(tr.ID)
+		}
+		if m.connErr == nil {
+			m.evt.Player.OnTitle()
 		}
 	})
 	pm.OnVolumeChange(func(vol int) {


### PR DESCRIPTION
### Problem

The operating system toolbar's component to control Supersonic playback had its Seek functionality broken on Linux. When playing a song, seeking for a different position from Supersonic worked as expected, but seeking from the toolbar did nothing to the current track.

I found that the underlying reason was in `MPRISHandler.SetPosition`, as the `if m.curTrackPath == trackId` always returned false.

`m.curTrackPath` was the right value, but `trackId` was wrong: On the first song being played for a tracklist, `trackId` when trying to seek was set to `/org/mpris/MediaPlayer2/TrackList/NoTrack`. When moving to the next song, `trackId` then became the Track ID of the previously played song.

### Solution

Changing the call to `OnTitle()` is enough to fix the issue, as the MPRIS `Metadata()` generation depends on the value of `m.curTrackPath`. Because it was being called before changing its value, the received `trackId` was always off.