### PR TITLE
fix: MPRIS broken cover art on Linux

### DIFF
--- a/backend/app.go
+++ b/backend/app.go
@@ -265,7 +265,10 @@ func (a *App) setupMPV() error {
 
 func (a *App) setupMPRIS(mprisAppName string) {
 	a.MPRISHandler = NewMPRISHandler(mprisAppName, a.PlaybackManager)
-	a.MPRISHandler.ArtURLLookup = a.ImageManager.GetCoverArtUrl
+	a.MPRISHandler.ArtURLLookup = func(id string) (string, error) {
+		a.ImageManager.GetCoverThumbnail(id) // ensure image is cached locally
+		return a.ImageManager.GetCoverArtUrl(id)
+	}
 	a.MPRISHandler.OnRaise = func() error { a.callOnReactivate(); return nil }
 	a.MPRISHandler.OnQuit = func() error {
 		if a.OnExit == nil {


### PR DESCRIPTION
### Problem

When changing tracks, the toolbar display on Linux sometimes misses the track cover art, and displays a placeholder instead.

### Solution

Copy same callback as the one used for MacOS, which calls `GetCoverArtUrl` first, to avoid missing cover arts.