### PR TITLE
fix: Enable Loop mode sync for MPRIS

### DIFF
--- a/backend/mpris.go
+++ b/backend/mpris.go
@@ -73,6 +73,11 @@ func NewMPRISHandler(playerName string, pm *PlaybackManager) *MPRISHandler {
 			m.evt.Player.OnVolume()
 		}
 	})
+	pm.OnLoopModeChange(func(loopMode LoopMode) {
+		if m.connErr == nil {
+			m.evt.Player.OnOptions()
+		}
+	})
 	emitPlayStatus := func() {
 		if m.connErr == nil {
 			m.evt.Player.OnPlayPause()


### PR DESCRIPTION
Loop mode changes were being correctly reflected in Supersonic, when updated in the toolbar, but not the other way around. We were only missing an `Options` changes emit when loop mode is changed in Supersonic.