### PR TITLE
misc: Decouple Grid view from Albums

### DIFF
--- a/backend/mediaprovider/subsonic/trackiterator.go
+++ b/backend/mediaprovider/subsonic/trackiterator.go
@@ -10,8 +10,11 @@ import (
 func (s *subsonicMediaProvider) IterateTracks(searchQuery string) mediaprovider.TrackIterator {
 	if searchQuery == "" {
 		return &allTracksIterator{
-			s:         s,
-			albumIter: s.IterateAlbums(AlbumSortArtistAZ, mediaprovider.AlbumFilter{}),
+			s: s,
+			albumIter: s.IterateAlbums(
+				AlbumSortArtistAZ,
+				mediaprovider.NewAlbumFilter(mediaprovider.AlbumFilterOptions{}),
+			),
 		}
 	}
 	return &searchTracksIterator{

--- a/ui/browsing/favoritespage.go
+++ b/ui/browsing/favoritespage.go
@@ -51,13 +51,15 @@ type FavoritesPage struct {
 
 func NewFavoritesPage(cfg *backend.FavoritesPageConfig, pool *util.WidgetPool, contr *controller.Controller, mp mediaprovider.MediaProvider, pm *backend.PlaybackManager, im *backend.ImageManager) *FavoritesPage {
 	a := &FavoritesPage{
-		filter: mediaprovider.AlbumFilter{ExcludeUnfavorited: true},
-		cfg:    cfg,
-		pool:   pool,
-		contr:  contr,
-		pm:     pm,
-		mp:     mp,
-		im:     im,
+		filter: mediaprovider.NewAlbumFilter(mediaprovider.AlbumFilterOptions{
+			ExcludeUnfavorited: true,
+		}),
+		cfg:   cfg,
+		pool:  pool,
+		contr: contr,
+		pm:    pm,
+		mp:    mp,
+		im:    im,
 	}
 	a.ExtendBaseWidget(a)
 	a.createHeader(0)
@@ -95,7 +97,7 @@ func (a *FavoritesPage) createHeader(activeBtnIdx int) {
 	a.searcher.PlaceHolder = "Search page"
 	a.searcher.OnSearched = a.OnSearched
 	a.searcher.Entry.Text = a.searchText
-	a.filterBtn = widgets.NewAlbumFilterButton(&a.filter, a.mp.GetGenres)
+	a.filterBtn = widgets.NewAlbumFilterButton(a.filter, a.mp.GetGenres)
 	a.filterBtn.FavoriteDisabled = true
 	a.filterBtn.OnChanged = a.Reload
 }

--- a/ui/browsing/genrepage.go
+++ b/ui/browsing/genrepage.go
@@ -13,10 +13,12 @@ import (
 )
 
 type genrePageAdapter struct {
-	genre string
-	contr *controller.Controller
-	mp    mediaprovider.MediaProvider
-	pm    *backend.PlaybackManager
+	genre     string
+	contr     *controller.Controller
+	mp        mediaprovider.MediaProvider
+	pm        *backend.PlaybackManager
+	filter    mediaprovider.AlbumFilter
+	filterBtn *widgets.AlbumFilterButton
 }
 
 func NewGenrePage(genre string, pool *util.WidgetPool, contr *controller.Controller, pm *backend.PlaybackManager, mp mediaprovider.MediaProvider, im *backend.ImageManager) Page {
@@ -26,8 +28,22 @@ func NewGenrePage(genre string, pool *util.WidgetPool, contr *controller.Control
 
 func (g *genrePageAdapter) Title() string { return g.genre }
 
-func (g *genrePageAdapter) Filter() *mediaprovider.AlbumFilter {
-	return &mediaprovider.AlbumFilter{Genres: []string{g.genre}}
+func (g *genrePageAdapter) Filter() mediaprovider.AlbumFilter {
+	if g.filter == nil {
+		g.filter = mediaprovider.NewAlbumFilter(
+			mediaprovider.AlbumFilterOptions{
+				Genres: []string{g.genre},
+			},
+		)
+	}
+	return g.filter
+}
+
+func (g *genrePageAdapter) FilterButton() widgets.FilterButton[mediaprovider.Album, mediaprovider.AlbumFilterOptions] {
+	if g.filterBtn == nil {
+		g.filterBtn = widgets.NewAlbumFilterButton(g.Filter(), g.mp.GetGenres)
+	}
+	return g.filterBtn
 }
 
 func (g *genrePageAdapter) PlaceholderResource() fyne.Resource {

--- a/ui/widgets/filterbutton.go
+++ b/ui/widgets/filterbutton.go
@@ -1,0 +1,13 @@
+package widgets
+
+import (
+	"fyne.io/fyne/v2"
+	"github.com/dweymouth/supersonic/backend/mediaprovider"
+)
+
+type FilterButton[M, F any] interface {
+	fyne.CanvasObject
+
+	Filter() mediaprovider.MediaFilter[M, F]
+	SetOnChanged(func())
+}

--- a/ui/widgets/gridview.go
+++ b/ui/widgets/gridview.go
@@ -18,23 +18,23 @@ import (
 
 const batchFetchSize = 6
 
-type BatchingIterator struct {
-	iter mediaprovider.AlbumIterator
+type BatchingIterator[M any] struct {
+	iter mediaprovider.MediaIterator[M]
 }
 
-func NewBatchingIterator(iter mediaprovider.AlbumIterator) BatchingIterator {
-	return BatchingIterator{iter}
+func NewBatchingIterator[M any](iter mediaprovider.MediaIterator[M]) BatchingIterator[M] {
+	return BatchingIterator[M]{iter}
 }
 
-func (b *BatchingIterator) NextN(n int) []*mediaprovider.Album {
-	results := make([]*mediaprovider.Album, 0, n)
+func (b *BatchingIterator[M]) NextN(n int) []*M {
+	results := make([]*M, 0, n)
 	i := 0
 	for i < n {
-		album := b.iter.Next()
-		if album == nil {
+		value := b.iter.Next()
+		if value == nil {
 			break
 		}
-		results = append(results, album)
+		results = append(results, value)
 		i++
 	}
 	return results
@@ -45,7 +45,7 @@ type GridViewIterator interface {
 }
 
 type gridViewAlbumIterator struct {
-	iter BatchingIterator
+	iter BatchingIterator[mediaprovider.Album]
 }
 
 func (g gridViewAlbumIterator) NextN(n int) []GridViewItemModel {


### PR DESCRIPTION
The Grid view and related components were highly coupled to Albums, including the filter button that is currently used only for album filtering.

As part of the migration of Artists to Grid view, this is the smallest possible change to convert many of the existing code to generics/interfaces that will allow different media to be displayed and filtered by using Grid views.

The main changes in this diff are:

* Introduction of generics for Media types (`M`) and Filter options (`F`), which can be later extended to other entities besides Albums.
* Complete decoupling of `GridViewPage` and related components from Albums (making these pages also generic).
* Refactoring of Subsonic/Jellyfin specific code to understand these new generics when dealing with filtering logic.