### PR TITLE
fix: Avoid slices.Contains within tight loops

### DIFF
--- a/sharedutil/sharedutil.go
+++ b/sharedutil/sharedutil.go
@@ -98,8 +98,9 @@ func ReorderTracks(tracks []*mediaprovider.Track, idxToMove []int, op TrackReord
 	case MoveToTop:
 		topIdx := 0
 		botIdx := len(idxToMove)
+		idxToMoveSet := ToSet(idxToMove)
 		for i, t := range tracks {
-			if slices.Contains(idxToMove, i) {
+			if _, ok := idxToMoveSet[i]; ok {
 				newTracks[topIdx] = t
 				topIdx++
 			} else {
@@ -110,8 +111,9 @@ func ReorderTracks(tracks []*mediaprovider.Track, idxToMove []int, op TrackReord
 	case MoveToBottom:
 		topIdx := 0
 		botIdx := len(tracks) - len(idxToMove)
+		idxToMoveSet := ToSet(idxToMove)
 		for i, t := range tracks {
-			if slices.Contains(idxToMove, i) {
+			if _, ok := idxToMoveSet[i]; ok {
 				newTracks[botIdx] = t
 				botIdx++
 			} else {

--- a/ui/browsing/nowplayingpage.go
+++ b/ui/browsing/nowplayingpage.go
@@ -257,9 +257,10 @@ func (a *NowPlayingPage) Tapped(*fyne.PointEvent) {
 }
 
 func (a *NowPlayingPage) doSetNewTrackOrder(trackIDs []string, op sharedutil.TrackReorderOp) {
+	trackIDSet := sharedutil.ToSet(trackIDs)
 	idxs := make([]int, 0, len(trackIDs))
 	for i, tr := range a.queue {
-		if slices.Contains(trackIDs, tr.ID) {
+		if _, ok := trackIDSet[tr.ID]; ok {
 			idxs = append(idxs, i)
 		}
 	}

--- a/ui/browsing/playlistpage.go
+++ b/ui/browsing/playlistpage.go
@@ -3,7 +3,6 @@ package browsing
 import (
 	"fmt"
 	"log"
-	"slices"
 
 	"github.com/dweymouth/supersonic/backend"
 	"github.com/dweymouth/supersonic/backend/mediaprovider"
@@ -181,15 +180,15 @@ func (a *PlaylistPage) doSetNewTrackOrder(op sharedutil.TrackReorderOp) {
 	// Since the tracklist view may be sorted in a different order than the
 	// actual running order, we need to get the IDs of the selected tracks
 	// from the tracklist and convert them to indices in the *original* run order
-	ids := a.tracklist.SelectedTrackIDs()
-	idxs := make([]int, 0, len(ids))
+	idSet := sharedutil.ToSet(a.tracklist.SelectedTrackIDs())
+	idxs := make([]int, 0, len(idSet))
 	for i, tr := range a.tracks {
-		if slices.Contains(ids, tr.ID) {
+		if _, ok := idSet[tr.ID]; ok {
 			idxs = append(idxs, i)
 		}
 	}
 	newTracks := sharedutil.ReorderTracks(a.tracks, idxs, op)
-	ids = sharedutil.TracksToIDs(newTracks)
+	ids := sharedutil.TracksToIDs(newTracks)
 	if err := a.sm.Server.ReplacePlaylistTracks(a.playlistID, ids); err != nil {
 		log.Printf("error updating playlist: %s", err.Error())
 	} else {


### PR DESCRIPTION
Having a `slices.Contains` check within a `for` loop has a complexity of `O(n*m)`, with a worst case scenario of `O(n^2)` for when both collections have the same size.

This is because `slices.Contains` internally runs just a regular loop, checking for equality element by element.

Instead, this diff changes every occurence of this pattern to converting the collection we compare against to a set, and then running a faster lookup against it.