### PR TITLE
misc: Add FilterMapSlice util

### DIFF
--- a/sharedutil/sharedutil.go
+++ b/sharedutil/sharedutil.go
@@ -31,6 +31,19 @@ func MapSlice[T any, U any](ts []T, f func(T) U) []U {
 	return result
 }
 
+func FilterMapSlice[T any, U any](ts []T, f func(T) (U, bool)) []U {
+	if ts == nil {
+		return nil
+	}
+	result := make([]U, 0)
+	for _, t := range ts {
+		if u, ok := f(t); ok {
+			result = append(result, u)
+		}
+	}
+	return result
+}
+
 func Reversed[T any](ts []T) []T {
 	if ts == nil {
 		return nil

--- a/ui/util/tracklistutil.go
+++ b/ui/util/tracklistutil.go
@@ -18,21 +18,15 @@ func ToTrackListModels(trs []*mediaprovider.Track) []*TrackListModel {
 	})
 }
 
-func SelectedTrackModels(tracks []*TrackListModel) []*TrackListModel {
-	return sharedutil.FilterSlice(tracks, func(tm *TrackListModel) bool {
-		return tm.Selected
-	})
-}
-
 func SelectedTracks(tracks []*TrackListModel) []*mediaprovider.Track {
-	return sharedutil.MapSlice(SelectedTrackModels(tracks), func(tm *TrackListModel) *mediaprovider.Track {
-		return tm.Track
+	return sharedutil.FilterMapSlice(tracks, func(tm *TrackListModel) (*mediaprovider.Track, bool) {
+		return tm.Track, tm.Selected
 	})
 }
 
 func SelectedTrackIDs(tracks []*TrackListModel) []string {
-	return sharedutil.MapSlice(SelectedTrackModels(tracks), func(tm *TrackListModel) string {
-		return tm.Track.ID
+	return sharedutil.FilterMapSlice(tracks, func(tm *TrackListModel) (string, bool) {
+		return tm.Track.ID, tm.Selected
 	})
 }
 


### PR DESCRIPTION
For the scenarios where both `Filter` and `Map` are being applied, having this util should be faster, as it avoids the creation of an extra slice during the intermediate step.