### PR TITLE
feat: add "Play next" MenuItem

### DIFF
--- a/backend/app.go
+++ b/backend/app.go
@@ -324,7 +324,7 @@ func (a *App) LoadSavedPlayQueue() error {
 		return nil
 	}
 
-	if err := a.PlaybackManager.LoadTracks(queue.Tracks, false, false); err != nil {
+	if err := a.PlaybackManager.LoadTracks(queue.Tracks, Replace, false); err != nil {
 		return err
 	}
 	if queue.TrackIndex >= 0 {

--- a/backend/playbackmanager.go
+++ b/backend/playbackmanager.go
@@ -100,27 +100,27 @@ func (p *PlaybackManager) OnPlaying(cb func()) {
 }
 
 // Loads the specified album into the play queue.
-func (p *PlaybackManager) LoadAlbum(albumID string, appendToQueue bool, shuffle bool) error {
+func (p *PlaybackManager) LoadAlbum(albumID string, insertQueueMode InsertQueueMode, shuffle bool) error {
 	album, err := p.engine.sm.Server.GetAlbum(albumID)
 	if err != nil {
 		return err
 	}
-	return p.LoadTracks(album.Tracks, appendToQueue, shuffle)
+	return p.LoadTracks(album.Tracks, insertQueueMode, shuffle)
 }
 
 // Loads the specified playlist into the play queue.
-func (p *PlaybackManager) LoadPlaylist(playlistID string, appendToQueue bool, shuffle bool) error {
+func (p *PlaybackManager) LoadPlaylist(playlistID string, insertQueueMode InsertQueueMode, shuffle bool) error {
 	playlist, err := p.engine.sm.Server.GetPlaylist(playlistID)
 	if err != nil {
 		return err
 	}
-	return p.LoadTracks(playlist.Tracks, appendToQueue, shuffle)
+	return p.LoadTracks(playlist.Tracks, insertQueueMode, shuffle)
 }
 
 // Load tracks into the play queue.
 // If replacing the current queue (!appendToQueue), playback will be stopped.
-func (p *PlaybackManager) LoadTracks(tracks []*mediaprovider.Track, appendToQueue, shuffle bool) error {
-	return p.engine.LoadTracks(tracks, appendToQueue, shuffle)
+func (p *PlaybackManager) LoadTracks(tracks []*mediaprovider.Track, insertQueueMode InsertQueueMode, shuffle bool) error {
+	return p.engine.LoadTracks(tracks, insertQueueMode, shuffle)
 }
 
 // Replaces the play queue with the given set of tracks.
@@ -131,7 +131,7 @@ func (p *PlaybackManager) UpdatePlayQueue(tracks []*mediaprovider.Track) error {
 }
 
 func (p *PlaybackManager) PlayAlbum(albumID string, firstTrack int, shuffle bool) error {
-	if err := p.LoadAlbum(albumID, false, shuffle); err != nil {
+	if err := p.LoadAlbum(albumID, Replace, shuffle); err != nil {
 		return err
 	}
 	if p.engine.replayGainCfg.Mode == ReplayGainAuto {
@@ -141,7 +141,7 @@ func (p *PlaybackManager) PlayAlbum(albumID string, firstTrack int, shuffle bool
 }
 
 func (p *PlaybackManager) PlayPlaylist(playlistID string, firstTrack int, shuffle bool) error {
-	if err := p.LoadPlaylist(playlistID, false, shuffle); err != nil {
+	if err := p.LoadPlaylist(playlistID, Replace, shuffle); err != nil {
 		return err
 	}
 	if p.engine.replayGainCfg.Mode == ReplayGainAuto {
@@ -155,7 +155,7 @@ func (p *PlaybackManager) PlayTrack(trackID string) error {
 	if err != nil {
 		return err
 	}
-	p.LoadTracks([]*mediaprovider.Track{tr}, false, false)
+	p.LoadTracks([]*mediaprovider.Track{tr}, Replace, false)
 	if p.engine.replayGainCfg.Mode == ReplayGainAuto {
 		p.SetReplayGainMode(player.ReplayGainTrack)
 	}
@@ -186,7 +186,7 @@ func (p *PlaybackManager) fetchAndPlayTracks(fetchFn func() ([]*mediaprovider.Tr
 	if songs, err := fetchFn(); err != nil {
 		log.Printf("error fetching tracks: %s", err.Error())
 	} else {
-		p.LoadTracks(songs, false, false)
+		p.LoadTracks(songs, Replace, false)
 		if p.engine.replayGainCfg.Mode == ReplayGainAuto {
 			p.SetReplayGainMode(player.ReplayGainTrack)
 		}

--- a/ui/browsing/albumpage.go
+++ b/ui/browsing/albumpage.go
@@ -226,7 +226,7 @@ func NewAlbumPageHeader(page *AlbumPage) *AlbumPageHeader {
 		go a.page.pm.PlayAlbum(a.page.albumID, 0, false)
 	})
 	shuffleBtn := widget.NewButtonWithIcon("Shuffle", myTheme.ShuffleIcon, func() {
-		a.page.pm.LoadTracks(a.page.tracklist.GetTracks(), false, true)
+		a.page.pm.LoadTracks(a.page.tracklist.GetTracks(), backend.Replace, true)
 		a.page.pm.PlayFromBeginning()
 	})
 	var pop *widget.PopUpMenu
@@ -234,7 +234,7 @@ func NewAlbumPageHeader(page *AlbumPage) *AlbumPageHeader {
 	menuBtn.OnTapped = func() {
 		if pop == nil {
 			queue := fyne.NewMenuItem("Add to queue", func() {
-				go a.page.pm.LoadAlbum(a.albumID, true /*append*/, false /*shuffle*/)
+				go a.page.pm.LoadAlbum(a.albumID, backend.Append, false /*shuffle*/)
 			})
 			queue.Icon = theme.ContentAddIcon()
 			playlist := fyne.NewMenuItem("Add to playlist...", func() {

--- a/ui/browsing/playlistpage.go
+++ b/ui/browsing/playlistpage.go
@@ -253,19 +253,23 @@ func NewPlaylistPageHeader(page *PlaylistPage) *PlaylistPageHeader {
 	})
 	a.editButton.Hidden = true
 	playButton := widget.NewButtonWithIcon("Play", theme.MediaPlayIcon(), func() {
-		a.page.pm.LoadTracks(a.page.tracks, false, false)
+		a.page.pm.LoadTracks(a.page.tracks, backend.Replace, false)
 		a.page.pm.PlayFromBeginning()
 	})
 	shuffleBtn := widget.NewButtonWithIcon("Shuffle", myTheme.ShuffleIcon, func() {
-		a.page.pm.LoadTracks(a.page.tracks, false /*append*/, true /*shuffle*/)
+		a.page.pm.LoadTracks(a.page.tracks, backend.Replace, true)
 		a.page.pm.PlayFromBeginning()
 	})
 	var pop *widget.PopUpMenu
 	menuBtn := widget.NewButtonWithIcon("", theme.MoreHorizontalIcon(), nil)
 	menuBtn.OnTapped = func() {
 		if pop == nil {
+			queue_next := fyne.NewMenuItem("Play next", func() {
+				go a.page.pm.LoadPlaylist(a.page.playlistID, backend.InsertNext, false)
+			})
+			queue_next.Icon = theme.ContentAddIcon()
 			queue := fyne.NewMenuItem("Add to queue", func() {
-				go a.page.pm.LoadPlaylist(a.page.playlistID, true /*append*/, false /*shuffle*/)
+				go a.page.pm.LoadPlaylist(a.page.playlistID, backend.Append, false)
 			})
 			queue.Icon = theme.ContentAddIcon()
 			playlist := fyne.NewMenuItem("Add to playlist...", func() {
@@ -277,7 +281,7 @@ func NewPlaylistPageHeader(page *PlaylistPage) *PlaylistPageHeader {
 				a.page.contr.ShowDownloadDialog(a.page.tracks, a.titleLabel.String())
 			})
 			download.Icon = theme.DownloadIcon()
-			menu := fyne.NewMenu("", queue, playlist, download)
+			menu := fyne.NewMenu("", queue_next, queue, playlist, download)
 			pop = widget.NewPopUpMenu(menu, fyne.CurrentApp().Driver().CanvasForObject(a))
 		}
 		pos := fyne.CurrentApp().Driver().AbsolutePositionForObject(menuBtn)

--- a/ui/browsing/playlistspage.go
+++ b/ui/browsing/playlistspage.go
@@ -123,7 +123,7 @@ func (a *PlaylistsPage) createGridView(playlists []*mediaprovider.Playlist) {
 		go a.contr.App.PlaybackManager.PlayPlaylist(id, 0, shuffle)
 	}
 	a.gridView.OnAddToQueue = func(id string) {
-		go a.contr.App.PlaybackManager.LoadPlaylist(id, true, false)
+		go a.contr.App.PlaybackManager.LoadPlaylist(id, backend.Append, false)
 	}
 	a.gridView.OnShowItemPage = a.showPlaylistPage
 	a.gridView.OnShowSecondaryPage = nil

--- a/ui/widgets/gridview.go
+++ b/ui/widgets/gridview.go
@@ -117,6 +117,7 @@ type GridViewState struct {
 	DisableSharing bool
 
 	OnPlay              func(id string, shuffle bool)
+	OnPlayNext          func(id string)
 	OnAddToQueue        func(id string)
 	OnAddToPlaylist     func(id string)
 	OnDownload          func(id string)
@@ -403,6 +404,12 @@ func (g *GridView) showContextMenu(card *GridViewItem, pos fyne.Position) {
 		play.Icon = theme.MediaPlayIcon()
 		shuffle := fyne.NewMenuItem("Shuffle", func() { g.onPlay(g.menuGridViewItemId, true) })
 		shuffle.Icon = myTheme.ShuffleIcon
+		queue_next := fyne.NewMenuItem("Play next", func() {
+			if g.OnPlayNext != nil {
+				g.OnPlayNext(g.menuGridViewItemId)
+			}
+		})
+		queue_next.Icon = theme.ContentAddIcon()
 		queue := fyne.NewMenuItem("Add to queue", func() {
 			if g.OnAddToQueue != nil {
 				g.OnAddToQueue(g.menuGridViewItemId)
@@ -425,7 +432,7 @@ func (g *GridView) showContextMenu(card *GridViewItem, pos fyne.Position) {
 			g.OnShare(g.menuGridViewItemId)
 		})
 		g.shareMenuItem.Icon = myTheme.ShareIcon
-		g.menu = widget.NewPopUpMenu(fyne.NewMenu("", play, shuffle, queue, playlist, download, g.shareMenuItem),
+		g.menu = widget.NewPopUpMenu(fyne.NewMenu("", play, shuffle, queue_next, queue, playlist, download, g.shareMenuItem),
 			fyne.CurrentApp().Driver().CanvasForObject(g))
 	}
 	g.shareMenuItem.Disabled = g.DisableSharing

--- a/ui/widgets/tracklist.go
+++ b/ui/widgets/tracklist.go
@@ -84,15 +84,16 @@ type Tracklist struct {
 	Options TracklistOptions
 
 	// user action callbacks
-	OnPlayTrackAt   func(int)
-	OnPlaySelection func(tracks []*mediaprovider.Track, shuffle bool)
-	OnAddToQueue    func(trackIDs []*mediaprovider.Track)
-	OnAddToPlaylist func(trackIDs []string)
-	OnSetFavorite   func(trackIDs []string, fav bool)
-	OnSetRating     func(trackIDs []string, rating int)
-	OnDownload      func(tracks []*mediaprovider.Track, downloadName string)
-	OnShare         func(trackID string)
-	OnPlaySongRadio func(track *mediaprovider.Track)
+	OnPlayTrackAt       func(int)
+	OnPlaySelection     func(tracks []*mediaprovider.Track, shuffle bool)
+	OnPlaySelectionNext func(trackIDs []*mediaprovider.Track)
+	OnAddToQueue        func(trackIDs []*mediaprovider.Track)
+	OnAddToPlaylist     func(trackIDs []string)
+	OnSetFavorite       func(trackIDs []string, fav bool)
+	OnSetRating         func(trackIDs []string, rating int)
+	OnDownload          func(tracks []*mediaprovider.Track, downloadName string)
+	OnShare             func(trackID string)
+	OnPlaySongRadio     func(track *mediaprovider.Track)
 
 	OnShowArtistPage func(artistID string)
 	OnShowAlbumPage  func(albumID string)
@@ -535,6 +536,12 @@ func (t *Tracklist) onShowContextMenu(e *fyne.PointEvent, trackIdx int) {
 				}
 			})
 			shuffle.Icon = myTheme.ShuffleIcon
+			play_next := fyne.NewMenuItem("Play next", func() {
+				if t.OnPlaySelection != nil {
+					t.OnPlaySelectionNext(t.selectedTracks())
+				}
+			})
+			play_next.Icon = theme.ContentAddIcon()
 			add := fyne.NewMenuItem("Add to queue", func() {
 				if t.OnPlaySelection != nil {
 					t.OnAddToQueue(t.selectedTracks())
@@ -546,7 +553,7 @@ func (t *Tracklist) onShowContextMenu(e *fyne.PointEvent, trackIdx int) {
 			})
 			t.songRadioMenuItem.Icon = myTheme.BroadcastIcon
 			t.ctxMenu.Items = append(t.ctxMenu.Items,
-				play, shuffle, add, t.songRadioMenuItem)
+				play, shuffle, play_next, add, t.songRadioMenuItem)
 		}
 		playlist := fyne.NewMenuItem("Add to playlist...", func() {
 			if t.OnAddToPlaylist != nil {


### PR DESCRIPTION
This PR add a MenuItem "Play next" where a "Add to queue" already exists. Instead of append the tracks at the end of the play queue, it will insert them right after the currently playing track.

A corresponding logo (and unique) is still missing.

![image](https://github.com/dweymouth/supersonic/assets/29518484/307a8e21-d4e3-4c6e-a9d7-338034ed928a)
