### PR TITLE
add option to configure queue size

### DIFF
--- a/backend/app.go
+++ b/backend/app.go
@@ -119,7 +119,7 @@ func StartupApp(appName, displayAppName, appVersionTag, latestReleaseURL string)
 	}
 
 	a.ServerManager = NewServerManager(appName, a.Config, !portableMode /*use keyring*/)
-	a.PlaybackManager = NewPlaybackManager(a.bgrndCtx, a.ServerManager, a.LocalPlayer, &a.Config.Scrobbling, &a.Config.Transcoding)
+	a.PlaybackManager = NewPlaybackManager(a.bgrndCtx, a.ServerManager, a.LocalPlayer, &a.Config.Scrobbling, &a.Config.Transcoding, &a.Config.Application)
 	a.ImageManager = NewImageManager(a.bgrndCtx, a.ServerManager, cacheDir)
 	a.Config.Application.MaxImageCacheSizeMB = clamp(a.Config.Application.MaxImageCacheSizeMB, 1, 500)
 	a.ImageManager.SetMaxOnDiskCacheSizeBytes(int64(a.Config.Application.MaxImageCacheSizeMB) * 1_048_576)

--- a/backend/config.go
+++ b/backend/config.go
@@ -48,6 +48,7 @@ type AppConfig struct {
 	ShowTrackChangeNotification bool
 	EnableLrcLib                bool
 	SkipSSLVerify               bool
+	EnqueueBatchSize 	    int
 
 	// Experimental - may be removed in future
 	FontNormalTTF string
@@ -173,6 +174,7 @@ func DefaultConfig(appVersionTag string) *Config {
 			ShowTrackChangeNotification: false,
 			EnableLrcLib:                true,
 			SkipSSLVerify:               false,
+			EnqueueBatchSize:	     100,
 		},
 		AlbumPage: AlbumPageConfig{
 			TracklistColumns: []string{"Artist", "Time", "Plays", "Favorite", "Rating"},

--- a/backend/playbackmanager.go
+++ b/backend/playbackmanager.go
@@ -14,6 +14,7 @@ import (
 type PlaybackManager struct {
 	engine   *playbackEngine
 	cmdQueue *playbackCommandQueue
+	cfg	 *AppConfig
 }
 
 func NewPlaybackManager(
@@ -22,12 +23,14 @@ func NewPlaybackManager(
 	p player.BasePlayer,
 	scrobbleCfg *ScrobbleConfig,
 	transcodeCfg *TranscodingConfig,
+	appCfg	     *AppConfig,
 ) *PlaybackManager {
 	e := NewPlaybackEngine(ctx, s, p, scrobbleCfg, transcodeCfg)
 	q := NewCommandQueue()
 	pm := &PlaybackManager{
 		engine:   e,
 		cmdQueue: q,
+		cfg: appCfg,
 	}
 	go pm.runCmdQueue(ctx)
 	return pm
@@ -231,13 +234,13 @@ func (p *PlaybackManager) PlayTrackAt(idx int) {
 
 func (p *PlaybackManager) PlayRandomSongs(genreName string) {
 	p.fetchAndPlayTracks(func() ([]*mediaprovider.Track, error) {
-		return p.engine.sm.Server.GetRandomTracks(genreName, 100)
+		return p.engine.sm.Server.GetRandomTracks(genreName, p.cfg.EnqueueBatchSize)
 	})
 }
 
 func (p *PlaybackManager) PlaySimilarSongs(id string) {
 	p.fetchAndPlayTracks(func() ([]*mediaprovider.Track, error) {
-		return p.engine.sm.Server.GetSimilarTracks(id, 100)
+		return p.engine.sm.Server.GetSimilarTracks(id, p.cfg.EnqueueBatchSize)
 	})
 }
 


### PR DESCRIPTION
When playing random songs supersonic had a hardcoded value of 100. This was very small for my taste. This PR add the option to configure it. 

I found out, however, that the current algorithm is worryingly slow. With a value of 1000 it takes more than 20 seconds on my computer. Recovering the queue when restarting supersonic is also very slow. 