### PR TITLE
Add caching for lrclib lyrics

### DIFF
--- a/backend/app.go
+++ b/backend/app.go
@@ -57,7 +57,7 @@ type App struct {
 	displayAppName string
 	appVersionTag  string
 	configDir      string
-	cacheDir       string
+	CacheDir       string
 	portableMode   bool
 
 	isFirstLaunch bool // set by config file reader
@@ -103,7 +103,7 @@ func StartupApp(appName, displayAppName, appVersion, appVersionTag, latestReleas
 		displayAppName: displayAppName,
 		appVersionTag:  appVersionTag,
 		configDir:      confDir,
-		cacheDir:       cacheDir,
+		CacheDir:       cacheDir,
 		portableMode:   portableMode,
 	}
 	a.bgrndCtx, a.cancel = context.WithCancel(context.Background())
@@ -411,7 +411,7 @@ func (a *App) LoginToDefaultServer(string) error {
 }
 
 func (a *App) DeleteServerCacheDir(serverID uuid.UUID) error {
-	path := path.Join(a.cacheDir, serverID.String())
+	path := path.Join(a.CacheDir, serverID.String())
 	log.Printf("Deleting server cache dir: %s", path)
 	return os.RemoveAll(path)
 }

--- a/backend/lrclib.go
+++ b/backend/lrclib.go
@@ -2,10 +2,15 @@ package backend
 
 import (
 	"context"
+	"crypto/md5"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log"
 	"net/http"
+	"os"
+	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
@@ -13,6 +18,38 @@ import (
 
 	"github.com/dweymouth/supersonic/backend/mediaprovider"
 )
+
+func FetchLrcLibLyricsCached(name, artist, album string, durationSecs int, cacheDir string) (*mediaprovider.Lyrics, error) {
+	hash := makeTrackIdHash(name, artist, album)
+	cacheFilePath := filepath.Join(cacheDir, fmt.Sprintf("%s_lyrics.txt", hash))
+
+	// File is cached. Try to use it
+	if _, err := os.Stat(cacheFilePath); err == nil {
+		lyrics, err := readCachedLyrics(cacheFilePath)
+		if err == nil {
+			return lyrics, nil
+		}
+
+		// On an error, remove the file.
+		if !os.IsNotExist(err) {
+			os.Remove(cacheFilePath)
+		}
+	}
+
+	// Fetch the lyrics
+	lyrics, err := FetchLrcLibLyrics(name, artist, album, durationSecs)
+	if err != nil {
+		return nil, err
+	}
+
+	// Try to write it into cache
+	err = writeCachedLyrics(cacheFilePath, lyrics)
+	if err != nil {
+		log.Printf("Failed to serialize fetched lyrics: %s", err)
+	}
+
+	return lyrics, nil
+}
 
 // FetchLrcLibLyrics is a static function to search and fetch lyrics from lrclib.net
 func FetchLrcLibLyrics(name, artist, album string, durationSecs int) (*mediaprovider.Lyrics, error) {
@@ -104,4 +141,47 @@ type lrcLibResponse struct {
 	Instrumental bool    `json:"instrumental"`
 	PlainLyrics  string  `json:"plainLyrics"`
 	SyncedLyrics string  `json:"syncedLyrics"`
+}
+
+// Write lyrics to the given file.
+func writeCachedLyrics(cacheFile string, lyrics *mediaprovider.Lyrics) error {
+	serialized, err := json.Marshal(lyrics)
+	if err != nil {
+		return err
+	}
+
+	f, err := os.Create(cacheFile)
+	if err != nil {
+		return nil
+	}
+	defer f.Close()
+
+	f.Write(serialized)
+
+	return nil
+}
+
+// Read lyrics from the given cache file.
+func readCachedLyrics(cacheFile string) (*mediaprovider.Lyrics, error) {
+	cachedBytes, err := os.ReadFile(cacheFile)
+	if err != nil {
+		return nil, err
+	}
+
+	var lyrics mediaprovider.Lyrics
+
+	err = json.Unmarshal(cachedBytes, &lyrics)
+	if err != nil {
+		return nil, err
+	}
+
+	return &lyrics, nil
+}
+
+// Create a "unique" hash for a song to identify it.
+func makeTrackIdHash(name, artist, album string) string {
+	hasher := md5.New()
+	identifier := fmt.Sprintf("%s;%s;%s", name, artist, album)
+	hasher.Write([]byte(identifier))
+	return hex.EncodeToString(hasher.Sum(nil))
 }

--- a/backend/lrclib.go
+++ b/backend/lrclib.go
@@ -16,12 +16,17 @@ import (
 	"strings"
 	"time"
 
+	"github.com/20after4/configdir"
 	"github.com/dweymouth/supersonic/backend/mediaprovider"
 )
 
+const CACHE_LYRICS_FOLDER = "lyrics"
+
 func FetchLrcLibLyricsCached(name, artist, album string, durationSecs int, cacheDir string) (*mediaprovider.Lyrics, error) {
-	hash := makeTrackIdHash(name, artist, album)
-	cacheFilePath := filepath.Join(cacheDir, fmt.Sprintf("%s_lyrics.txt", hash))
+	hash := makeTrackIdHash(name, artist, album, durationSecs)
+	cachePath := filepath.Join(cacheDir, CACHE_LYRICS_FOLDER)
+	configdir.MakePath(cachePath)
+	cacheFilePath := filepath.Join(cachePath, fmt.Sprintf("%s_lyrics.txt", hash))
 
 	// File is cached. Try to use it
 	if _, err := os.Stat(cacheFilePath); err == nil {
@@ -179,9 +184,9 @@ func readCachedLyrics(cacheFile string) (*mediaprovider.Lyrics, error) {
 }
 
 // Create a "unique" hash for a song to identify it.
-func makeTrackIdHash(name, artist, album string) string {
+func makeTrackIdHash(name, artist, album string, durationSecs int) string {
 	hasher := md5.New()
-	identifier := fmt.Sprintf("%s;%s;%s", name, artist, album)
+	identifier := fmt.Sprintf("%s;%s;%s;%d", name, artist, album, durationSecs)
 	hasher.Write([]byte(identifier))
 	return hex.EncodeToString(hasher.Sum(nil))
 }

--- a/backend/mediaprovider/model.go
+++ b/backend/mediaprovider/model.go
@@ -150,10 +150,10 @@ type PlaylistWithTracks struct {
 }
 
 type Lyrics struct {
-	Title  string
-	Artist string
-	Synced bool
-	Lines  []LyricLine
+	Title  string      `json:"title"`
+	Artist string      `json:"artist"`
+	Synced bool        `json:"synced"`
+	Lines  []LyricLine `json:"lines"`
 }
 
 type LyricLine struct {

--- a/ui/browsing/nowplayingpage.go
+++ b/ui/browsing/nowplayingpage.go
@@ -81,6 +81,7 @@ type nowPlayingPageState struct {
 	canRate  bool
 	canShare bool
 	lrcLib   bool
+	cacheDir string
 }
 
 func NewNowPlayingPage(
@@ -94,9 +95,10 @@ func NewNowPlayingPage(
 	canRate bool,
 	canShare bool,
 	lrcLibEnabled bool,
+	cacheDir string,
 ) *NowPlayingPage {
 	state := nowPlayingPageState{
-		conf: conf, contr: contr, pool: pool, sm: sm, im: im, pm: pm, mp: mp, canRate: canRate, canShare: canShare, lrcLib: lrcLibEnabled,
+		conf: conf, contr: contr, pool: pool, sm: sm, im: im, pm: pm, mp: mp, canRate: canRate, canShare: canShare, lrcLib: lrcLibEnabled, cacheDir: cacheDir,
 	}
 	if page, ok := pool.Obtain(util.WidgetTypeNowPlayingPage).(*NowPlayingPage); ok && page != nil {
 		page.nowPlayingPageState = state
@@ -362,7 +364,7 @@ func (a *NowPlayingPage) fetchLyrics(ctx context.Context, song *mediaprovider.Tr
 		}
 	}
 	if lyrics == nil {
-		lyrics, err = backend.FetchLrcLibLyrics(song.Title, song.ArtistNames[0], song.Album, song.Duration)
+		lyrics, err = backend.FetchLrcLibLyricsCached(song.Title, song.ArtistNames[0], song.Album, song.Duration, a.cacheDir)
 		if err != nil {
 			log.Println(err.Error())
 		}
@@ -450,7 +452,7 @@ func (a *NowPlayingPage) Reload() {
 }
 
 func (s *nowPlayingPageState) Restore() Page {
-	return NewNowPlayingPage(s.conf, s.contr, s.pool, s.sm, s.im, s.pm, s.mp, s.canRate, s.canShare, s.lrcLib)
+	return NewNowPlayingPage(s.conf, s.contr, s.pool, s.sm, s.im, s.pm, s.mp, s.canRate, s.canShare, s.lrcLib, s.cacheDir)
 }
 
 var _ CanShowPlayTime = (*NowPlayingPage)(nil)

--- a/ui/browsing/router.go
+++ b/ui/browsing/router.go
@@ -48,7 +48,7 @@ func (r Router) CreatePage(rte controller.Route) Page {
 	case controller.Genres:
 		return NewGenresPage(r.Controller, r.App.ServerManager.Server)
 	case controller.NowPlaying:
-		return NewNowPlayingPage(&r.App.Config.NowPlayingConfig, r.Controller, r.widgetPool, r.App.ServerManager, r.App.ImageManager, r.App.PlaybackManager, r.App.ServerManager.Server, canRate, canShare, r.App.Config.Application.EnableLrcLib)
+		return NewNowPlayingPage(&r.App.Config.NowPlayingConfig, r.Controller, r.widgetPool, r.App.ServerManager, r.App.ImageManager, r.App.PlaybackManager, r.App.ServerManager.Server, canRate, canShare, r.App.Config.Application.EnableLrcLib, r.App.CacheDir)
 	case controller.Playlist:
 		return NewPlaylistPage(rte.Arg, &r.App.Config.PlaylistPage, r.widgetPool, r.Controller, r.App.ServerManager, r.App.PlaybackManager, r.App.ImageManager)
 	case controller.Playlists:


### PR DESCRIPTION
Adds cache for the following reasons:
- Reduce unnecessary API calls
- Allows showing lyrics if external server aren't reachable
- Slightly improves on privacy, since the server only sees the first time a song gets played

My go has become a bit rusty over the time so please feel free to suggest a cleaner way of this implementation if you aren't happy with my approach