### PR TITLE
Custom lrclib url config

### DIFF
--- a/backend/app.go
+++ b/backend/app.go
@@ -146,7 +146,7 @@ func StartupApp(appName, displayAppName, appVersion, appVersionTag, latestReleas
 		_, _ = a.ImageManager.GetCoverThumbnail(coverID)
 	})
 	if a.Config.Application.EnableLrcLib {
-		a.LrcLibFetcher = NewLrcLibFetcher(a.cacheDir)
+		a.LrcLibFetcher = NewLrcLibFetcher(a.cacheDir, a.Config.Application.CustomLrcLibUrl)
 	}
 
 	a.PlaybackManager.OnPlaying(func() {

--- a/backend/config.go
+++ b/backend/config.go
@@ -47,6 +47,7 @@ type AppConfig struct {
 	AddToPlaylistSkipDuplicates bool
 	ShowTrackChangeNotification bool
 	EnableLrcLib                bool
+	CustomLrcLibUrl             string
 	EnablePasswordStorage       bool
 	SkipSSLVerify               bool
 	EnqueueBatchSize            int


### PR DESCRIPTION
Depends on #544 
(I'll rebase this PR once the other one is merged)

Since Lrclib [can be selfhosted](https://github.com/tranxuanthang/lrclib), it is possible to use a different server than the public one.
This PR allows setting a different lrclib server URL in the config.

Reasons to do so:
- Privacy
- Personal lyrics database (since lrclib.net doesn't allow adding new lyrics)