### PR TITLE
Clamp volume slider scrolling

### DIFF
--- a/ui/widgets/auxcontrols.go
+++ b/ui/widgets/auxcontrols.go
@@ -1,6 +1,8 @@
 package widgets
 
 import (
+	"math"
+
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/container"
 	"fyne.io/fyne/v2/lang"
@@ -129,7 +131,7 @@ func (v *volumeSlider) MinSize() fyne.Size {
 }
 
 func (v *volumeSlider) Scrolled(e *fyne.ScrollEvent) {
-	v.SetValue(v.Value + float64(0.5*e.Scrolled.DY))
+	v.SetValue(v.Value + math.Max(-10, math.Min(10, float64(0.5*e.Scrolled.DY))))
 }
 
 type VolumeControl struct {


### PR DESCRIPTION
For some reason my compositor reports a delta of 70 in scroll events so the volume slider makes a large 35% jump every scroll notch. Clamping to 10% seems reasonable.