### PR TITLE
Fix crash in Windows SMTC

### DIFF
--- a/backend/app.go
+++ b/backend/app.go
@@ -403,8 +403,8 @@ func (a *App) SetupWindowsSMTC(hwnd uintptr) {
 		}()
 	})
 	a.PlaybackManager.OnSeek(func() {
-		dur := a.PlaybackManager.NowPlaying().Metadata().Duration
-		smtc.UpdatePosition(int(a.PlaybackManager.PlaybackStatus().TimePos*1000), dur*1000)
+		playbackStatus := a.PlaybackManager.PlaybackStatus()
+		smtc.UpdatePosition(int(playbackStatus.TimePos*1000), int(playbackStatus.Duration*1000))
 	})
 	a.PlaybackManager.OnPlaying(func() {
 		smtc.SetEnabled(true)


### PR DESCRIPTION
Instead of using the NowPlaying() metadata (which is sometimes nil, and so would require some error handling), we now use the PlaybackStatus().

Notice that PlaybackStatus() will return information from the pendingPlayerChangeStatus, which if I understand correctly is the track we're *about* to start playing.

Fixes #590, fixes #581, fixes #562