### PR TITLE
Add golangci lint and unused lint

### DIFF
--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -1,0 +1,27 @@
+# https://github.com/marketplace/actions/golangci-lint
+name: golangci-lint
+on:
+  push:
+    branches:
+  pull_request:
+
+permissions:
+  contents: read
+  # Optional: allow read access to pull request. Use with `only-new-issues` option.
+  pull-requests: read
+
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: stable
+      - name: Install dependencies
+        run: sudo apt update && sudo apt install libmpv-dev gcc libegl1-mesa-dev xorg-dev
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: v1.64

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,48 @@
+run:
+  go: "1.21"
+  issues-exit-code: 1
+  tests: true
+  timeout: 10m
+linters:
+  enable:
+    - unused
+  disable:
+    - asasalint
+    - asciicheck
+    - bidichk
+    - bodyclose
+    - contextcheck
+    - durationcheck
+    - errcheck
+    - errchkjson
+    - errorlint
+    - exhaustive
+    - gocheckcompilerdirectives
+    - gochecksumtype
+    - gosec
+    - gosmopolitan
+    - govet
+    - loggercheck
+    - makezero
+    - musttag
+    - nilerr
+    - nilnesserr
+    - noctx
+    - protogetter
+    - reassign
+    - recvcheck
+    - rowserrcheck
+    - spancheck
+    - sqlclosecheck
+    - staticcheck
+    - testifylint
+    - unparam
+    - zerologlint
+  presets:
+    - bugs
+    - unused
+  fast: false
+
+linters-settings:
+  gofmt:
+    simplify: true

--- a/Makefile
+++ b/Makefile
@@ -29,3 +29,7 @@ package_windows:
 
 package_linux:
 	fyne package -os linux -tags migrated_fynedo
+
+.PHONY: lint
+lint:
+	golangci-lint run

--- a/backend/player/dlna/dlnaplayer.go
+++ b/backend/player/dlna/dlnaplayer.go
@@ -31,8 +31,6 @@ const (
 	paused  = 2
 )
 
-var unimplemented = errors.New("unimplemented")
-
 type proxyMapEntry struct {
 	key string
 	url string

--- a/backend/player/jukebox/jukeboxplayer.go
+++ b/backend/player/jukebox/jukeboxplayer.go
@@ -27,7 +27,6 @@ type JukeboxPlayer struct {
 	curTrackDuration   float64
 	startTrackTime     float64
 	startedAtUnixMilli int64
-	nextTrackTimer     *time.Timer
 }
 
 func (j *JukeboxPlayer) SetVolume(vol int) error {

--- a/backend/player/jukebox/jukeboxplayer.go
+++ b/backend/player/jukebox/jukeboxplayer.go
@@ -154,7 +154,3 @@ func (j *JukeboxPlayer) startAndUpdateTime() error {
 	j.startedAtUnixMilli = time.Now().Add(-afterStart.Sub(beforeStart)).UnixMilli()
 	return nil
 }
-
-func (j *JukeboxPlayer) handleNextTrack() {
-
-}

--- a/ui/browsing/nowplayingpage.go
+++ b/ui/browsing/nowplayingpage.go
@@ -506,11 +506,6 @@ func (a *NowPlayingPage) Refresh() {
 	a.BaseWidget.Refresh()
 }
 
-func (a *NowPlayingPage) doSetNewTrackOrder(idxs []int, insertPos int) {
-	newTracks := sharedutil.ReorderItems(a.queue, idxs, insertPos)
-	a.pm.UpdatePlayQueue(newTracks)
-}
-
 func (a *NowPlayingPage) saveSelectedTab(tabNum int) {
 	var tabName string
 	switch tabNum {

--- a/ui/widgets/imagepopup.go
+++ b/ui/widgets/imagepopup.go
@@ -14,7 +14,6 @@ type ImagePopUp struct {
 
 	img         image.Image
 	desiredSize fyne.Size
-	aspect      float64
 }
 
 func NewImagePopUp(img image.Image, canv fyne.Canvas, size fyne.Size) *ImagePopUp {

--- a/ui/widgets/imagepopup.go
+++ b/ui/widgets/imagepopup.go
@@ -9,10 +9,6 @@ import (
 	myTheme "github.com/dweymouth/supersonic/ui/theme"
 )
 
-const (
-	imagePopUpLowRezDim = 128
-)
-
 type ImagePopUp struct {
 	widget.PopUp
 


### PR DESCRIPTION
This adds `golangci-lint` as a linter for the project, through a configuration, a
makefile recipe, and ci.  I've reverted one of the fixes to demonstrate the ci fail,
and will remove said commit if we deem these changes worthy of merging. 

If something like this is not desired for the project, that's cool too, let me know.
If this is OK, I can start enabling the rest of the lints and submit more patches.

Cheers!

Edit: here's what it looks like: https://github.com/psyomn/supersonic/actions/workflows/build-appimage.yml 
I think annotations should show up in PRs if I understood the actions correctly.