### PR TITLE
Add playback speed control (0.25x - 4x) with UI selector

### DIFF
--- a/backend/playbackcommands.go
+++ b/backend/playbackcommands.go
@@ -17,6 +17,7 @@ const (
 	cmdSeekSeconds  // arg: float64
 	cmdSeekFwdBackN // arg: int
 	cmdVolume       // arg: int
+	cmdSpeed        // arg: float64
 	cmdLoopMode     // arg: LoopMode
 	cmdStopAndClearPlayQueue
 	cmdUpdatePlayQueue       // arg: []mediaprovider.MediaItem
@@ -102,6 +103,11 @@ func (c *playbackCommandQueue) StopAndClearPlayQueue() {
 func (c *playbackCommandQueue) SetVolume(vol int) {
 	c.filterCommandsAndAdd([]playbackCommandType{cmdVolume},
 		playbackCommand{Type: cmdVolume, Arg: vol})
+}
+
+func (c *playbackCommandQueue) SetSpeed(speed float64) {
+	c.filterCommandsAndAdd([]playbackCommandType{cmdSpeed},
+		playbackCommand{Type: cmdSpeed, Arg: speed})
 }
 
 func (c *playbackCommandQueue) SetLoopMode(mode LoopMode) {

--- a/backend/playbackengine.go
+++ b/backend/playbackengine.go
@@ -287,6 +287,15 @@ func (p *playbackEngine) SetVolume(vol int) error {
 	return nil
 }
 
+func (p *playbackEngine) SetSpeed(speed float64) error {
+	if speed < 0.25 {
+		speed = 0.25
+	} else if speed > 4.0 {
+		speed = 4.0
+	}
+	return p.player.SetSpeed(speed)
+}
+
 func (p *playbackEngine) CurrentPlayer() player.BasePlayer {
 	return p.player
 }

--- a/backend/playbackmanager.go
+++ b/backend/playbackmanager.go
@@ -624,6 +624,14 @@ func (p *PlaybackManager) Volume() int {
 	return p.engine.CurrentPlayer().GetVolume()
 }
 
+func (p *PlaybackManager) SetSpeed(speed float64) {
+	p.cmdQueue.SetSpeed(speed)
+}
+
+func (p *PlaybackManager) Speed() float64 {
+	return p.engine.CurrentPlayer().GetSpeed()
+}
+
 func (p *PlaybackManager) SeekNext() {
 	p.cmdQueue.SeekNext()
 }
@@ -804,6 +812,8 @@ func (p *PlaybackManager) runCmdQueue(ctx context.Context) {
 				logIfErr(action, p.engine.SeekFwdBackN(c.Arg.(int)))
 			case cmdVolume:
 				logIfErr("Volume", p.engine.SetVolume(c.Arg.(int)))
+			case cmdSpeed:
+				logIfErr("Speed", p.engine.SetSpeed(c.Arg.(float64)))
 			case cmdLoopMode:
 				p.engine.SetLoopMode(c.Arg.(LoopMode))
 			case cmdStopAndClearPlayQueue:

--- a/backend/player/dlna/dlnaplayer.go
+++ b/backend/player/dlna/dlnaplayer.go
@@ -141,6 +141,17 @@ func (d *DLNAPlayer) GetVolume() int {
 	return vol
 }
 
+// SetSpeed is not supported for DLNA players, returns nil (no-op).
+func (d *DLNAPlayer) SetSpeed(speed float64) error {
+	// DLNA/UPnP does not typically support playback speed control
+	return nil
+}
+
+// GetSpeed always returns 1.0 for DLNA players as speed control is not supported.
+func (d *DLNAPlayer) GetSpeed() float64 {
+	return 1.0
+}
+
 func (d *DLNAPlayer) PlayFile(urlstr string, meta mediaprovider.MediaItemMetadata, startTime float64) error {
 	if d.destroyed {
 		return nil

--- a/backend/player/jukebox/jukeboxplayer.go
+++ b/backend/player/jukebox/jukeboxplayer.go
@@ -41,6 +41,17 @@ func (j *JukeboxPlayer) GetVolume() int {
 	return j.volume
 }
 
+// SetSpeed is not supported for Jukebox players, returns nil (no-op).
+func (j *JukeboxPlayer) SetSpeed(speed float64) error {
+	// Jukebox mode does not support playback speed control
+	return nil
+}
+
+// GetSpeed always returns 1.0 for Jukebox players as speed control is not supported.
+func (j *JukeboxPlayer) GetSpeed() float64 {
+	return 1.0
+}
+
 func (j *JukeboxPlayer) Continue() error {
 	if j.state == playing {
 		return nil

--- a/backend/player/mpv/player.go
+++ b/backend/player/mpv/player.go
@@ -68,6 +68,7 @@ type Player struct {
 	clientName     string
 	equalizer      Equalizer
 	peaksEnabled   bool
+	speed          float64
 
 	fileLoadedLock sync.Mutex
 	fileLoadedSig  *sync.Cond
@@ -233,6 +234,32 @@ func (p *Player) SetVolume(vol int) error {
 	}
 	p.vol = vol
 	return nil
+}
+
+// Sets the playback speed of the player (0.25-4.0).
+// Speed value of 1.0 is normal speed.
+func (p *Player) SetSpeed(speed float64) error {
+	if !p.initialized {
+		return ErrUnitialized
+	}
+	if speed < 0.25 {
+		speed = 0.25
+	} else if speed > 4.0 {
+		speed = 4.0
+	}
+	err := p.mpv.SetProperty("speed", mpv.FORMAT_DOUBLE, speed)
+	if err == nil {
+		p.speed = speed
+	}
+	return err
+}
+
+// Gets the current playback speed of the player.
+func (p *Player) GetSpeed() float64 {
+	if p.speed == 0 {
+		return 1.0 // default speed
+	}
+	return p.speed
 }
 
 // Sets the ReplayGain options of the player.

--- a/backend/player/player.go
+++ b/backend/player/player.go
@@ -27,6 +27,9 @@ type BasePlayer interface {
 	SetVolume(int) error
 	GetVolume() int
 
+	SetSpeed(float64) error
+	GetSpeed() float64
+
 	GetStatus() Status
 
 	Destroy()

--- a/ui/bottompanel.go
+++ b/ui/bottompanel.go
@@ -120,6 +120,11 @@ func NewBottomPanel(pm *backend.PlaybackManager, im *backend.ImageManager, contr
 	bp.AuxControls.OnChangeAutoplay = func(autoplay bool) {
 		pm.SetAutoplay(autoplay)
 	}
+	bp.AuxControls.OnChangeSpeed = func(speed float64) {
+		pm.SetSpeed(speed)
+	}
+	// Set initial speed from playback manager
+	bp.AuxControls.SetSpeed(pm.Speed())
 	bp.AuxControls.OnShowPlayQueue(contr.ShowPopUpPlayQueue)
 	bp.AuxControls.OnShowCastMenu(contr.ShowCastMenu)
 


### PR DESCRIPTION
This PR adds playback speed control functionality to Supersonic, allowing users to adjust playback speed from 0.25x to 4.0x in 0.25x increments.