### PR TITLE
Fixes #785 : Missing translations

### DIFF
--- a/res/translations/de.json
+++ b/res/translations/de.json
@@ -243,9 +243,14 @@
     "Oct": "Okt",
     "Nov": "Nov",
     "Dec": "Dec",
-
     "playlist.addedtracks": {
-        "one": "Added {{.trackCount}} track to playlist",
-        "other": "Added {{.trackCount}} tracks to playlist"
+        "other": "{{.trackCount}} Titel zur Playlist hinzugefügt"
+    },
+    "{{.trackCount}} tracks": {
+        "other": "{{.trackCount}} Titel"
+    },
+    "{{.albumsCount}} albums": {
+        "one": "{{.albumsCount}} Album",
+        "other": "{{.albumsCount}} Alben"
     }
 }

--- a/res/translations/en.json
+++ b/res/translations/en.json
@@ -322,5 +322,13 @@
     "x_years_ago": {
         "one": "a year ago",
         "other": "{{.years}} years ago"
+    },
+    "{{.trackCount}} tracks": {
+        "one": "{{.trackCount}} track",
+        "other": "{{.trackCount}} tracks"
+    },
+    "{{.albumsCount}} albums": {
+        "one": "{{.albumsCount}} album",
+        "other": "{{.albumsCount}} albums"
     }
 }


### PR DESCRIPTION
Added missing translations(en/de) for:
   - `"{{.trackCount}} tracks"`
   - `"{{.albumsCount}} albums"`

Fixed the German translation for `"playlist.addedtracks"`