### PR TITLE
Fix ko-fi image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <img src="res/appicon-128.png" alt="Supersonic logo" title="Supersonic" align="left" height="60px"/>
 <a href='https://flathub.org/apps/details/io.github.dweymouth.supersonic'><img height="50px" align="right" alt='Download on Flathub' src='https://flathub.org/assets/badges/flathub-badge-en.png'/></a>
-<a href='https://ko-fi.com/dweymouth'><img height='40' align='right' src='[https://az743702.vo.msecnd.net/cdn/kofi3.png?v=0](https://cdn.ko-fi.com/cdn/kofi1.png?v=3)' border='0' alt='Buy Me a Coffee at ko-fi.com'/></a>
+<a href='https://ko-fi.com/dweymouth'><img height='40' align='right' src='https://cdn.ko-fi.com/cdn/kofi1.png?v=3' border='0' alt='Buy Me a Coffee at ko-fi.com'/></a>
 
 # Supersonic
 


### PR DESCRIPTION
Fixed ko-fi image but clicks on it and flathub's one are still being blocked by the image/title element.
