### PR TITLE
Closes #794: Added 30min timeout to all jobs

### DIFF
--- a/.github/workflows/build-appimage.yml
+++ b/.github/workflows/build-appimage.yml
@@ -12,6 +12,7 @@ jobs:
 
   build:
     runs-on: ubuntu-22.04
+    timeout-minutes: 30
     steps:
     - uses: actions/checkout@v3
 

--- a/.github/workflows/build-macos-arm64.yml
+++ b/.github/workflows/build-macos-arm64.yml
@@ -12,6 +12,7 @@ on:
 jobs:
   build:
     runs-on: macos-14
+    timeout-minutes: 30
     steps:
     - uses: actions/checkout@v3
 

--- a/.github/workflows/build-macos-x64.yml
+++ b/.github/workflows/build-macos-x64.yml
@@ -12,6 +12,7 @@ on:
 jobs:
   build:
     runs-on: macos-15-intel
+    timeout-minutes: 30
     steps:
     - uses: actions/checkout@v3
 

--- a/.github/workflows/build-ubuntu-22.04.yml
+++ b/.github/workflows/build-ubuntu-22.04.yml
@@ -12,6 +12,7 @@ jobs:
 
   build:
     runs-on: ubuntu-22.04
+    timeout-minutes: 30
     steps:
     - uses: actions/checkout@v3
 

--- a/.github/workflows/build-ubuntu-24.04.yml
+++ b/.github/workflows/build-ubuntu-24.04.yml
@@ -12,6 +12,7 @@ jobs:
 
   build:
     runs-on: ubuntu-24.04
+    timeout-minutes: 30
     steps:
     - uses: actions/checkout@v3
 

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -12,6 +12,7 @@ on:
 jobs:
   build:
     runs-on: windows-latest
+    timeout-minutes: 30
     defaults:
       run:
         shell: msys2 {0}

--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -14,6 +14,7 @@ jobs:
   golangci:
     name: lint
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5


### PR DESCRIPTION
- Added a 30min timeout to each job
- this overrides the github default of 360min
- For reference: https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idstepstimeout-minutes

If you'd like the option to configure the timeout at project level instead of at job level, this would be a way to do it: https://github.com/orgs/community/discussions/14834#discussioncomment-5903876 

FWIW I think this would be a cleaner solution, but requires an extra env-variable
