### PR TITLE
Fix equalizer audio filter string construction

### DIFF
--- a/backend/player/mpv/player.go
+++ b/backend/player/mpv/player.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 


### PR DESCRIPTION
## Summary
- Fix audio filter string construction that caused equalizer to not work
- The af property was being set with a leading comma when peaks were disabled, causing mpv to reject it with "unsupported format" error