### PR TITLE
Configure MPV to use PipeWire with proper app name and metadata

### DIFF
--- a/backend/app.go
+++ b/backend/app.go
@@ -328,7 +328,9 @@ func (a *App) callOnExit() error {
 }
 
 func (a *App) initMPV() error {
-	p := mpv.NewWithClientName(a.appName)
+	// Use standard desktop file base name for audio client identification
+	// This matches the desktop file name without .desktop extension
+	p := mpv.NewWithClientName("io.github.dweymouth.supersonic")
 	c := a.Config.LocalPlayback
 	c.InMemoryCacheSizeMB = clamp(c.InMemoryCacheSizeMB, 10, 500)
 	if err := p.Init(c.InMemoryCacheSizeMB); err != nil {

--- a/backend/player/mpv/player.go
+++ b/backend/player/mpv/player.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -110,6 +111,13 @@ func (p *Player) Init(maxCacheMB int) error {
 		m.SetOptionString("force-seekable", "yes")
 		m.SetOptionString("terminal", "no")
 
+		// Linux-specific: Configure PulseAudio/PipeWire for proper audio stream identification
+		if runtime.GOOS == "linux" {
+			m.SetOptionString("ao", "pulse,pipewire,alsa")
+			// Set title to show "Artist - Track" in PipeWire metadata
+			m.SetOptionString("title", "${?metadata/by-key/Artist:${metadata/by-key/Artist} - }${media-title}")
+		}
+
 		// limit in-memory cache size
 		maxBackMB := maxCacheMB / 3
 		maxForwardMB := maxBackMB + maxBackMB
@@ -128,6 +136,11 @@ func (p *Player) Init(maxCacheMB int) error {
 
 		if p.clientName != "" {
 			m.SetOptionString("audio-client-name", p.clientName)
+		}
+
+		// Linux-specific: Set x11-name for proper window manager integration
+		if runtime.GOOS == "linux" {
+			m.SetOptionString("x11-name", "io.github.dweymouth.supersonic")
 		}
 
 		if err := m.Initialize(); err != nil {

--- a/res/io.github.dweymouth.supersonic.desktop
+++ b/res/io.github.dweymouth.supersonic.desktop
@@ -8,6 +8,6 @@ Keywords=music;audio;player;subsonic;navidrome;streaming;
 Path=/usr/bin
 Exec=supersonic-desktop
 Terminal=false
-Icon=supersonic-desktop
+Icon=io.github.dweymouth.supersonic
 StartupWMClass=Supersonic
 Categories=Audio;AudioVideo;Music;Player;


### PR DESCRIPTION
- Set audio output to prefer pulse/pipewire over alsa for native stream support
- Use supersonic-desktop as client name to match desktop file for icon resolution
- Set x11-name to supersonic-desktop for proper window manager integration
- Configure title format to show Artist - Track in media metadata