### PR TITLE
Fix out of bounds panic when restoring EQ preset

### DIFF
--- a/ui/dialogs/settingsdialog.go
+++ b/ui/dialogs/settingsdialog.go
@@ -481,6 +481,13 @@ func (s *SettingsDialog) createPlaybackTab(isLocalPlayer, isReplayGainPlayer boo
 }
 
 func (s *SettingsDialog) createEqualizerTab(eqBands []string) *container.TabItem {
+	// Ensure GraphicEqualizerBands matches the expected number of bands
+	if len(s.config.LocalPlayback.GraphicEqualizerBands) != len(eqBands) {
+		newBands := make([]float64, len(eqBands))
+		copy(newBands, s.config.LocalPlayback.GraphicEqualizerBands)
+		s.config.LocalPlayback.GraphicEqualizerBands = newBands
+	}
+
 	enabled := widget.NewCheck(lang.L("Enabled"), func(b bool) {
 		s.config.LocalPlayback.EqualizerEnabled = b
 		if s.OnEqualizerSettingsChanged != nil {


### PR DESCRIPTION
  Fix a panic (index out of range [10] with length 10) when clicking the Reset button in the equalizer settings. The crash occurs when GraphicEqualizerBands in the config has fewer elements than the number of UI  sliders (e.g., 10 bands stored but 15-band EQ type active), causing an out-of-bounds write in the OnChanged callback.

  Changes:
  - Ensure GraphicEqualizerBands is resized to match the expected band count when the equalizer tab is created