### PR TITLE
Move shuffle and repeat buttons into main player controls

### DIFF
--- a/ui/bottompanel.go
+++ b/ui/bottompanel.go
@@ -88,7 +88,7 @@ func NewBottomPanel(pm *backend.PlaybackManager, im *backend.ImageManager, contr
 			contr.ShowShareDialog(tr.ID)
 		}
 	}
-	bp.Controls = widgets.NewPlayerControls(cfg.Playback.UseWaveformSeekbar)
+	bp.Controls = widgets.NewPlayerControls(cfg.Playback.UseWaveformSeekbar, pm.GetLoopMode(), pm.IsShuffle())
 	bp.Controls.OnPlayPause(func() {
 		pm.PlayPause()
 	})
@@ -101,14 +101,20 @@ func NewBottomPanel(pm *backend.PlaybackManager, im *backend.ImageManager, contr
 	bp.Controls.OnSeek(func(f float64) {
 		pm.SeekFraction(f)
 	})
-
-	bp.AuxControls = widgets.NewAuxControls(pm.Volume(), pm.GetLoopMode(), pm.IsAutoplay(), pm.IsShuffle())
+	bp.Controls.OnChangeLoopMode(func() {
+		pm.SetNextLoopMode()
+	})
+	bp.Controls.OnChangeShuffle = func(shuffle bool) {
+		pm.SetShuffle(shuffle)
+	}
 	pm.OnLoopModeChange(func(lm backend.LoopMode) {
-		fyne.Do(func() { bp.AuxControls.SetLoopMode(lm) })
+		fyne.Do(func() { bp.Controls.SetLoopMode(lm) })
 	})
-	pm.OnShuffleChange(func(lm bool) {
-		fyne.Do(func() { bp.AuxControls.SetShuffle(lm) })
+	pm.OnShuffleChange(func(sh bool) {
+		fyne.Do(func() { bp.Controls.SetShuffle(sh) })
 	})
+
+	bp.AuxControls = widgets.NewAuxControls(pm.Volume(), pm.IsAutoplay())
 	pm.OnVolumeChange(func(vol int) {
 		fyne.Do(func() { bp.AuxControls.VolumeControl.SetVolume(vol) })
 	})
@@ -119,14 +125,8 @@ func NewBottomPanel(pm *backend.PlaybackManager, im *backend.ImageManager, contr
 	bp.AuxControls.VolumeControl.OnSetVolume = func(v int) {
 		pm.SetVolume(v)
 	}
-	bp.AuxControls.OnChangeLoopMode(func() {
-		pm.SetNextLoopMode()
-	})
 	bp.AuxControls.OnChangeAutoplay = func(autoplay bool) {
 		pm.SetAutoplay(autoplay)
-	}
-	bp.AuxControls.OnChangeShuffle = func(shuffle bool) {
-		pm.SetShuffle(shuffle)
 	}
 	bp.AuxControls.OnShowPlayQueue(contr.ShowPopUpPlayQueue)
 	bp.AuxControls.OnShowCastMenu(contr.ShowCastMenu)

--- a/ui/widgets/auxcontrols.go
+++ b/ui/widgets/auxcontrols.go
@@ -11,7 +11,6 @@ import (
 	"fyne.io/fyne/v2/theme"
 	"fyne.io/fyne/v2/widget"
 
-	"github.com/dweymouth/supersonic/backend"
 	myTheme "github.com/dweymouth/supersonic/ui/theme"
 	"github.com/dweymouth/supersonic/ui/util"
 )
@@ -22,41 +21,22 @@ type AuxControls struct {
 	widget.BaseWidget
 
 	OnChangeAutoplay func(autoplay bool)
-	OnChangeShuffle  func(shuffle bool)
 
 	VolumeControl *VolumeControl
-	shuffle       *IconButton
 	autoplay      *IconButton
-	loop          *IconButton
 	cast          *IconButton
 	showQueue     *IconButton
 
 	container *fyne.Container
 }
 
-func NewAuxControls(initialVolume int, initialLoopMode backend.LoopMode, initialAutoplay bool, initialShuffle bool) *AuxControls {
+func NewAuxControls(initialVolume int, initialAutoplay bool) *AuxControls {
 	a := &AuxControls{
 		VolumeControl: NewVolumeControl(initialVolume),
-		shuffle:       NewIconButton(myTheme.ShuffleIcon, nil),
 		autoplay:      NewIconButton(myTheme.AutoplayIcon, nil),
-		loop:          NewIconButton(myTheme.RepeatIcon, nil),
 		cast:          NewIconButton(myTheme.CastIcon, nil),
 		showQueue:     NewIconButton(myTheme.PlayQueueIcon, nil),
 	}
-
-	a.shuffle.Highlighted = initialShuffle
-	a.shuffle.IconSize = IconButtonSizeSmaller
-	a.shuffle.SetToolTip(lang.L("Shuffle"))
-	a.shuffle.OnTapped = func() {
-		a.SetShuffle(!a.shuffle.Highlighted)
-		if a.OnChangeShuffle != nil {
-			a.OnChangeShuffle(a.shuffle.Highlighted)
-		}
-	}
-
-	a.loop.IconSize = IconButtonSizeSmaller
-	a.loop.SetToolTip(lang.L("Repeat"))
-	a.SetLoopMode(initialLoopMode)
 
 	a.cast.IconSize = IconButtonSizeSmaller
 	a.cast.SetToolTip(lang.L("Cast to device"))
@@ -81,7 +61,7 @@ func NewAuxControls(initialVolume int, initialLoopMode backend.LoopMode, initial
 			a.VolumeControl,
 			container.New(
 				layout.NewCustomPaddedHBoxLayout(theme.Padding()*1.5),
-				layout.NewSpacer(), a.autoplay, a.shuffle, a.loop, a.cast, a.showQueue, util.NewHSpace(5)),
+				layout.NewSpacer(), a.autoplay, a.cast, a.showQueue, util.NewHSpace(5)),
 			layout.NewSpacer(),
 		),
 	)
@@ -91,32 +71,6 @@ func NewAuxControls(initialVolume int, initialLoopMode backend.LoopMode, initial
 func (a *AuxControls) CreateRenderer() fyne.WidgetRenderer {
 	a.ExtendBaseWidget(a)
 	return widget.NewSimpleRenderer(a.container)
-}
-
-func (a *AuxControls) OnChangeLoopMode(f func()) {
-	a.loop.OnTapped = f
-}
-
-func (a *AuxControls) SetLoopMode(mode backend.LoopMode) {
-	switch mode {
-	case backend.LoopAll:
-		a.loop.Highlighted = true
-		a.loop.SetIcon(myTheme.RepeatIcon)
-	case backend.LoopOne:
-		a.loop.Highlighted = true
-		a.loop.SetIcon(myTheme.RepeatOneIcon)
-	case backend.LoopNone:
-		a.loop.Highlighted = false
-		a.loop.SetIcon(myTheme.RepeatIcon)
-	}
-}
-
-func (a *AuxControls) SetShuffle(isShuffle bool) {
-	if isShuffle == a.shuffle.Highlighted {
-		return
-	}
-	a.shuffle.Highlighted = isShuffle
-	a.shuffle.Refresh()
 }
 
 func (a *AuxControls) DisableCastButton() {

--- a/ui/widgets/iconbutton.go
+++ b/ui/widgets/iconbutton.go
@@ -16,8 +16,10 @@ type IconButtonSize int
 
 const (
 	IconButtonSizeNormal IconButtonSize = iota
+	IconButtonSizeSlightlyBigger
 	IconButtonSizeBigger
 	IconButtonSizeSmaller
+	IconButtonSizeSmallest
 )
 
 type IconButton struct {
@@ -141,8 +143,12 @@ func (i *IconButton) iconSize() fyne.Size {
 	switch i.IconSize {
 	case IconButtonSizeBigger:
 		return fyne.NewSquareSize(theme.IconInlineSize() * 2)
+	case IconButtonSizeSlightlyBigger:
+		return fyne.NewSquareSize(theme.IconInlineSize() * 1.37)
 	case IconButtonSizeSmaller:
 		return fyne.NewSquareSize(theme.IconInlineSize())
+	case IconButtonSizeSmallest:
+		return fyne.NewSquareSize(theme.IconInlineSize() * 0.9)
 	default:
 		return fyne.NewSquareSize(theme.IconInlineSize() * 1.3333)
 	}


### PR DESCRIPTION
## Summary

- Moves the shuffle button to the far left of the transport controls (left of Previous) and the repeat button to the far right (right of Next)
- Removes both buttons from `AuxControls`, simplifying it to volume, autoplay, cast, and queue
- Adds a new `IconButtonSizeSmallest` constant (90% of `IconButtonSizeSmaller`) for the slightly smaller shuffle/repeat icons
- Adds 2dp spacing between shuffle↔prev and next↔repeat using `util.NewHSpace`
- Updates wiring in `bottompanel.go` to connect shuffle/repeat callbacks through `PlayerControls`

## Test plan

- [x] Verify shuffle and repeat buttons appear flanking the prev/play/next buttons in the bottom panel
- [x] Verify shuffle toggles on/off correctly and state is reflected visually
- [x] Verify repeat cycles through none/all/one modes correctly
- [x] Verify shuffle and repeat buttons are no longer present in the aux controls area
- [x] Verify volume, autoplay, cast, and queue controls in aux area still work normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)