### PR TITLE
Add Deezer/Wikipedia artist info as fallback for all servers

### DIFF
--- a/backend/app.go
+++ b/backend/app.go
@@ -46,19 +46,20 @@ var (
 )
 
 type App struct {
-	Config          *Config
-	ServerManager   *ServerManager
-	LyricsManager   *LyricsManager
-	ImageManager    *ImageManager
-	AudioCache      *AudioCache
-	AutoEQManager   *AutoEQManager
-	EQPresetManager *EQPresetManager
-	PlaybackManager *PlaybackManager
-	LocalPlayer     *mpv.Player
-	UpdateChecker   UpdateChecker
-	MPRISHandler    *MPRISHandler
-	WinSMTC         *windows.SMTC
-	ipcServer       ipc.IPCServer
+	Config            *Config
+	ServerManager     *ServerManager
+	LyricsManager     *LyricsManager
+	ArtistInfoManager *ArtistInfoManager
+	ImageManager      *ImageManager
+	AudioCache        *AudioCache
+	AutoEQManager     *AutoEQManager
+	EQPresetManager   *EQPresetManager
+	PlaybackManager   *PlaybackManager
+	LocalPlayer       *mpv.Player
+	UpdateChecker     UpdateChecker
+	MPRISHandler      *MPRISHandler
+	WinSMTC           *windows.SMTC
+	ipcServer         ipc.IPCServer
 
 	// UI callbacks to be set in main
 	OnReactivate  func()
@@ -171,6 +172,13 @@ func StartupApp(appName, displayAppName, appVersion, appVersionTag, latestReleas
 		fetch = NewLrcLibFetcher(a.cacheDir, a.Config.Application.CustomLrcLibUrl, timeout)
 	}
 	a.LyricsManager = NewLyricsManager(a.ServerManager, fetch)
+
+	var aiFetcher *ArtistInfoFetcher
+	if a.Config.Application.EnableExternalArtistInfo {
+		aiFetcher = NewArtistInfoFetcher(a.Config.Application.Language)
+	}
+	a.ArtistInfoManager = NewArtistInfoManager(a.ServerManager, aiFetcher)
+
 	a.EQPresetManager = NewEQPresetManager(confDir)
 
 	// Initialize AutoEQ manager
@@ -287,6 +295,7 @@ func (a *App) ClearCaches() {
 		}
 	}
 	a.ImageManager.ClearInMemoryCache()
+	a.ArtistInfoManager.ClearCache()
 }
 
 func checkPortablePath() string {

--- a/backend/artistinfofetcher.go
+++ b/backend/artistinfofetcher.go
@@ -1,0 +1,351 @@
+package backend
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"regexp"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/dweymouth/supersonic/backend/mediaprovider"
+)
+
+const (
+	deezerBaseURL      = "https://api.deezer.com"
+	artistInfoTimeout  = 10 * time.Second
+	artistInfoCacheTTL = 24 * time.Hour
+	// Maximum number of concurrent external artist-info HTTP requests.
+	// Prevents thundering-herd when a full grid of artists loads at once.
+	maxConcurrentArtistFetches = 4
+)
+
+// artistInfoCacheEntry stores cached artist info with expiration.
+type artistInfoCacheEntry struct {
+	info      *mediaprovider.ArtistInfo
+	expiresAt time.Time
+}
+
+// inflightCall tracks an in-progress fetch so that concurrent callers for the
+// same artist can wait on the same result instead of all issuing HTTP requests.
+type inflightCall struct {
+	done chan struct{}
+	info *mediaprovider.ArtistInfo
+	err  error
+}
+
+// ArtistInfoFetcher fetches artist info from Deezer (images) and Wikipedia (biography).
+// It can be used as a fallback for any media server that doesn't provide complete
+// artist metadata (biography, images, etc.).
+type ArtistInfoFetcher struct {
+	httpClient *http.Client
+	cache      map[string]artistInfoCacheEntry
+	cacheMu    sync.RWMutex
+	language   string // User's preferred language code (e.g., "it", "de", "fr")
+
+	// inflight deduplicates concurrent requests for the same artist.
+	inflightMu sync.Mutex
+	inflight   map[string]*inflightCall
+
+	// fetchSem limits the number of simultaneous outbound HTTP requests.
+	fetchSem chan struct{}
+}
+
+// NewArtistInfoFetcher creates a new ArtistInfoFetcher.
+// The language parameter sets the preferred Wikipedia language (e.g. "it", "de").
+// Use "" or "auto" to auto-detect from system locale.
+func NewArtistInfoFetcher(language string) *ArtistInfoFetcher {
+	return &ArtistInfoFetcher{
+		httpClient: &http.Client{
+			Timeout: artistInfoTimeout,
+		},
+		cache:    make(map[string]artistInfoCacheEntry),
+		inflight: make(map[string]*inflightCall),
+		fetchSem: make(chan struct{}, maxConcurrentArtistFetches),
+		language: language,
+	}
+}
+
+// ClearCache clears the in-memory artist info cache.
+func (f *ArtistInfoFetcher) ClearCache() {
+	f.cacheMu.Lock()
+	defer f.cacheMu.Unlock()
+	f.cache = make(map[string]artistInfoCacheEntry)
+}
+
+// FetchArtistInfo fetches artist info from Deezer (images) and Wikipedia (biography) with caching.
+// Concurrent calls for the same artist are deduplicated — only one HTTP round-trip is made.
+// Overall concurrency is bounded by maxConcurrentArtistFetches to avoid hammering external APIs.
+func (f *ArtistInfoFetcher) FetchArtistInfo(artistName string) (*mediaprovider.ArtistInfo, error) {
+	if artistName == "" {
+		return &mediaprovider.ArtistInfo{}, nil
+	}
+
+	cacheKey := strings.ToLower(artistName)
+
+	// Fast path: cache hit (read-lock only).
+	f.cacheMu.RLock()
+	if entry, ok := f.cache[cacheKey]; ok && time.Now().Before(entry.expiresAt) {
+		f.cacheMu.RUnlock()
+		return entry.info, nil
+	}
+	f.cacheMu.RUnlock()
+
+	// Deduplicate in-flight requests for the same artist.
+	f.inflightMu.Lock()
+	if call, ok := f.inflight[cacheKey]; ok {
+		// Another goroutine is already fetching this artist — wait for it.
+		f.inflightMu.Unlock()
+		<-call.done
+		return call.info, call.err
+	}
+	call := &inflightCall{done: make(chan struct{})}
+	f.inflight[cacheKey] = call
+	f.inflightMu.Unlock()
+
+	// Acquire semaphore slot to bound total concurrent HTTP requests.
+	f.fetchSem <- struct{}{}
+	defer func() { <-f.fetchSem }()
+
+	// Do the actual fetch.
+	info, err := f.fetchFromDeezer(artistName)
+	if err != nil {
+		info = &mediaprovider.ArtistInfo{}
+	}
+
+	biography, wikiURL := f.fetchBiographyFromWikipedia(artistName)
+	if biography != "" {
+		info.Biography = biography
+		if wikiURL != "" && info.LastFMUrl == "" {
+			info.LastFMUrl = wikiURL
+		}
+	}
+
+	// Store in cache.
+	f.cacheMu.Lock()
+	f.cache[cacheKey] = artistInfoCacheEntry{
+		info:      info,
+		expiresAt: time.Now().Add(artistInfoCacheTTL),
+	}
+	f.cacheMu.Unlock()
+
+	// Publish result and unblock waiters.
+	call.info = info
+	call.err = nil // Deezer/Wikipedia failures are swallowed; result is always non-nil.
+	close(call.done)
+
+	// Remove from in-flight map.
+	f.inflightMu.Lock()
+	delete(f.inflight, cacheKey)
+	f.inflightMu.Unlock()
+
+	return info, nil
+}
+
+// fetchFromDeezer fetches artist info from Deezer API.
+func (f *ArtistInfoFetcher) fetchFromDeezer(artistName string) (*mediaprovider.ArtistInfo, error) {
+	reqURL := fmt.Sprintf("%s/search/artist?q=%s", deezerBaseURL, url.QueryEscape(artistName))
+
+	req, err := http.NewRequest(http.MethodGet, reqURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("User-Agent", "Supersonic/1.0 (https://github.com/dweymouth/supersonic)")
+
+	resp, err := f.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch artist info: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("artist info fetch failed with status %d", resp.StatusCode)
+	}
+
+	var result deezerSearchResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	if result.Error.Code != 0 {
+		return nil, fmt.Errorf("deezer API error %d: %s", result.Error.Code, result.Error.Message)
+	}
+
+	if len(result.Data) == 0 {
+		return &mediaprovider.ArtistInfo{}, nil
+	}
+
+	// Find best match (exact name match preferred)
+	var bestMatch *deezerArtist
+	artistLower := strings.ToLower(artistName)
+	for i := range result.Data {
+		if strings.ToLower(result.Data[i].Name) == artistLower {
+			bestMatch = &result.Data[i]
+			break
+		}
+	}
+	if bestMatch == nil {
+		bestMatch = &result.Data[0]
+	}
+
+	info := &mediaprovider.ArtistInfo{}
+
+	// Prefer XL image, fall back to big, then medium
+	if bestMatch.PictureXL != "" && !isDeezerPlaceholder(bestMatch.PictureXL) {
+		info.ImageURL = bestMatch.PictureXL
+	} else if bestMatch.PictureBig != "" && !isDeezerPlaceholder(bestMatch.PictureBig) {
+		info.ImageURL = bestMatch.PictureBig
+	} else if bestMatch.PictureMedium != "" && !isDeezerPlaceholder(bestMatch.PictureMedium) {
+		info.ImageURL = bestMatch.PictureMedium
+	}
+
+	if bestMatch.Link != "" {
+		info.LastFMUrl = bestMatch.Link
+	}
+
+	return info, nil
+}
+
+// isDeezerPlaceholder checks if the URL is a Deezer default placeholder image.
+func isDeezerPlaceholder(imgURL string) bool {
+	return strings.Contains(imgURL, "/artist//") || strings.Contains(imgURL, "d-artist")
+}
+
+// fetchBiographyFromWikipedia fetches artist biography from Wikipedia.
+// It tries the user's preferred language first, then always falls back to English.
+func (f *ArtistInfoFetcher) fetchBiographyFromWikipedia(artistName string) (string, string) {
+	langs := []string{"en"}
+
+	lang := f.language
+	if lang == "" || lang == "auto" {
+		lang = getSystemLanguage()
+	}
+
+	if lang != "" && lang != "en" {
+		wikiLang := mapToWikipediaLang(lang)
+		if wikiLang != "" && wikiLang != "en" {
+			langs = []string{wikiLang, "en"}
+		}
+	}
+
+	for _, l := range langs {
+		extract, pageURL := f.fetchWikipediaBio(artistName, l)
+		if extract != "" {
+			return extract, pageURL
+		}
+	}
+
+	return "", ""
+}
+
+// getSystemLanguage detects the system language from environment variables.
+func getSystemLanguage() string {
+	for _, envVar := range []string{"LANG", "LC_MESSAGES", "LC_ALL", "LANGUAGE"} {
+		if val := os.Getenv(envVar); val != "" {
+			lang := strings.Split(val, "_")[0]
+			lang = strings.Split(lang, ".")[0]
+			if lang != "" && lang != "C" && lang != "POSIX" {
+				return lang
+			}
+		}
+	}
+	return ""
+}
+
+// mapToWikipediaLang maps app language codes to Wikipedia language codes.
+func mapToWikipediaLang(appLang string) string {
+	switch appLang {
+	case "zhHans", "zhHant", "zh":
+		return "zh"
+	case "pt_BR":
+		return "pt"
+	default:
+		return appLang
+	}
+}
+
+// isValidLangCode checks that a language code is safe to use in a URL hostname.
+var validLangCode = regexp.MustCompile(`^[a-z]{2,3}$`)
+
+func isValidLangCode(code string) bool {
+	return validLangCode.MatchString(code)
+}
+
+// fetchWikipediaBio fetches biography from a specific Wikipedia language edition.
+func (f *ArtistInfoFetcher) fetchWikipediaBio(artistName, wikiLang string) (string, string) {
+	// Validate language code to prevent URL injection
+	if !isValidLangCode(wikiLang) {
+		return "", ""
+	}
+
+	title := strings.ReplaceAll(artistName, " ", "_")
+	reqURL := fmt.Sprintf("https://%s.wikipedia.org/api/rest_v1/page/summary/%s", wikiLang, url.PathEscape(title))
+
+	req, err := http.NewRequest(http.MethodGet, reqURL, nil)
+	if err != nil {
+		return "", ""
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("User-Agent", "Supersonic/1.0 (https://github.com/dweymouth/supersonic)")
+
+	resp, err := f.httpClient.Do(req)
+	if err != nil {
+		return "", ""
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", ""
+	}
+
+	var result wikipediaSummary
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return "", ""
+	}
+
+	pageURL := ""
+	if result.ContentURLs.Desktop.Page != "" {
+		pageURL = result.ContentURLs.Desktop.Page
+	}
+
+	return result.Extract, pageURL
+}
+
+// Deezer API response types
+
+type deezerSearchResponse struct {
+	Data  []deezerArtist `json:"data"`
+	Error deezerError    `json:"error"`
+}
+
+type deezerError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+type deezerArtist struct {
+	ID            int    `json:"id"`
+	Name          string `json:"name"`
+	Link          string `json:"link"`
+	PictureSmall  string `json:"picture_small"`
+	PictureMedium string `json:"picture_medium"`
+	PictureBig    string `json:"picture_big"`
+	PictureXL     string `json:"picture_xl"`
+	NbFan         int    `json:"nb_fan"`
+}
+
+// Wikipedia API response types
+
+type wikipediaSummary struct {
+	Title       string `json:"title"`
+	Extract     string `json:"extract"`
+	ContentURLs struct {
+		Desktop struct {
+			Page string `json:"page"`
+		} `json:"desktop"`
+	} `json:"content_urls"`
+}

--- a/backend/artistinfomanager.go
+++ b/backend/artistinfomanager.go
@@ -1,0 +1,74 @@
+package backend
+
+import (
+	"log"
+
+	"github.com/dweymouth/supersonic/backend/mediaprovider"
+)
+
+// ArtistInfoManager provides artist info by first querying the media server,
+// then falling back to external sources (Deezer/Wikipedia) to fill in
+// missing biography or image data. This follows the same pattern as
+// LyricsManager with LrcLib fallback.
+type ArtistInfoManager struct {
+	sm      *ServerManager
+	fetcher *ArtistInfoFetcher
+}
+
+// NewArtistInfoManager creates a new ArtistInfoManager.
+// If fetcher is nil, no external fallback will be used.
+func NewArtistInfoManager(sm *ServerManager, fetcher *ArtistInfoFetcher) *ArtistInfoManager {
+	return &ArtistInfoManager{
+		sm:      sm,
+		fetcher: fetcher,
+	}
+}
+
+// GetArtistInfo fetches artist info, trying the server first and falling back
+// to Deezer/Wikipedia for missing biography or image data.
+// artistName is required for the external fallback to work.
+func (m *ArtistInfoManager) GetArtistInfo(artistID, artistName string) (*mediaprovider.ArtistInfo, error) {
+	var info *mediaprovider.ArtistInfo
+	var err error
+
+	// First, try the server's native artist info
+	if m.sm.Server != nil {
+		info, err = m.sm.Server.GetArtistInfo(artistID)
+		if err != nil {
+			log.Printf("Error fetching artist info from server: %v", err)
+		}
+	}
+	if info == nil {
+		info = &mediaprovider.ArtistInfo{}
+	}
+
+	// If external fetcher is available and we're missing data, try fallback
+	if m.fetcher != nil && artistName != "" {
+		if info.Biography == "" || info.ImageURL == "" {
+			fallback, fetchErr := m.fetcher.FetchArtistInfo(artistName)
+			if fetchErr != nil {
+				log.Printf("Error fetching external artist info: %v", fetchErr)
+			}
+			if fallback != nil {
+				if info.Biography == "" {
+					info.Biography = fallback.Biography
+				}
+				if info.ImageURL == "" {
+					info.ImageURL = fallback.ImageURL
+				}
+				if info.LastFMUrl == "" {
+					info.LastFMUrl = fallback.LastFMUrl
+				}
+			}
+		}
+	}
+
+	return info, nil
+}
+
+// ClearCache clears the external artist info cache.
+func (m *ArtistInfoManager) ClearCache() {
+	if m.fetcher != nil {
+		m.fetcher.ClearCache()
+	}
+}

--- a/backend/config.go
+++ b/backend/config.go
@@ -50,6 +50,7 @@ type AppConfig struct {
 	ShowTrackChangeNotification bool
 	EnableLrcLib                bool
 	CustomLrcLibUrl             string
+	EnableExternalArtistInfo    bool
 	EnablePasswordStorage       bool
 	SkipSSLVerify               bool // Deprecated: use per-server SkipSSLVerify. Drop in future version.
 	EnqueueBatchSize            int
@@ -136,7 +137,7 @@ type LocalPlaybackConfig struct {
 	InMemoryCacheSizeMB   int
 	Volume                int
 	EqualizerEnabled      bool
-	EqualizerType         string    // "ISO10Band" or "ISO15Band"
+	EqualizerType         string // "ISO10Band" or "ISO15Band"
 	EqualizerPreamp       float64
 	GraphicEqualizerBands []float64
 	ActiveEQPresetName    string // Name of currently selected EQ preset
@@ -217,6 +218,7 @@ func DefaultConfig(appVersionTag string) *Config {
 			SaveQueueToServer:                  false,
 			ShowTrackChangeNotification:        false,
 			EnableLrcLib:                       true,
+			EnableExternalArtistInfo:           true,
 			EnablePasswordStorage:              true,
 			EnqueueBatchSize:                   100,
 			Language:                           "auto",

--- a/res/translations/en.json
+++ b/res/translations/en.json
@@ -109,6 +109,7 @@
     "Edit": "Edit",
     "Edit Playlist": "Edit Playlist",
     "Edit server": "Edit server",
+    "Enable Deezer/Wikipedia artist info": "Enable Deezer/Wikipedia artist info",
     "Enable LrcLib lyrics fetcher": "Enable LrcLib lyrics fetcher",
     "Enable OS media player integration": "Enable OS media player integration",
     "Enable system tray": "Enable system tray",

--- a/res/translations/it.json
+++ b/res/translations/it.json
@@ -109,6 +109,7 @@
     "Edit": "Modifica",
     "Edit Playlist": "Modifica playlist",
     "Edit server": "Modifica server",
+    "Enable Deezer/Wikipedia artist info": "Abilita info artista da Deezer/Wikipedia",
     "Enable LrcLib lyrics fetcher": "Abilita recupero testi da LrcLib",
     "Enable OS media player integration": "Abilita integrazione con il player multimediale del sistema",
     "Enable system tray": "Abilita barra di sistema",

--- a/ui/browsing/artistpage.go
+++ b/ui/browsing/artistpage.go
@@ -40,6 +40,7 @@ type artistPageState struct {
 	cfg   *backend.ArtistPageConfig
 	pm    *backend.PlaybackManager
 	mp    mediaprovider.MediaProvider
+	aim   *backend.ArtistInfoManager
 	im    *backend.ImageManager
 	contr *controller.Controller
 
@@ -77,7 +78,7 @@ const (
 	viewAllTracks   = "All Tracks"
 )
 
-func NewArtistPage(artistID string, cfg *backend.ArtistPageConfig, pool *util.WidgetPool, pm *backend.PlaybackManager, mp mediaprovider.MediaProvider, im *backend.ImageManager, contr *controller.Controller) *ArtistPage {
+func NewArtistPage(artistID string, cfg *backend.ArtistPageConfig, pool *util.WidgetPool, pm *backend.PlaybackManager, mp mediaprovider.MediaProvider, aim *backend.ArtistInfoManager, im *backend.ImageManager, contr *controller.Controller) *ArtistPage {
 	activeView := 0
 
 	switch cfg.InitialView {
@@ -95,6 +96,7 @@ func NewArtistPage(artistID string, cfg *backend.ArtistPageConfig, pool *util.Wi
 		pool:       pool,
 		pm:         pm,
 		mp:         mp,
+		aim:        aim,
 		im:         im,
 		contr:      contr,
 		activeView: activeView,
@@ -330,10 +332,11 @@ func (a *ArtistPage) load() {
 		a.onViewChange(a.activeView)
 	})
 
-	info, err := a.mp.GetArtistInfo(a.artistID)
-	if err != nil {
-		log.Printf("Failed to get artist info: %s", err.Error())
+	artistName := ""
+	if artist != nil {
+		artistName = artist.Name
 	}
+	info, _ := a.aim.GetArtistInfo(a.artistID, artistName)
 	fyne.Do(func() {
 		if !a.disposed {
 			a.header.UpdateInfo(info)

--- a/ui/browsing/router.go
+++ b/ui/browsing/router.go
@@ -40,7 +40,7 @@ func (r Router) CreatePage(rte controller.Route) Page {
 	case controller.Albums:
 		return NewAlbumsPage(&r.App.Config.AlbumsPage, r.widgetPool, r.Controller, r.App.PlaybackManager, r.App.ServerManager.Server, r.App.ImageManager)
 	case controller.Artist:
-		return NewArtistPage(rte.Arg, &r.App.Config.ArtistPage, r.widgetPool, r.App.PlaybackManager, r.App.ServerManager.Server, r.App.ImageManager, r.Controller)
+		return NewArtistPage(rte.Arg, &r.App.Config.ArtistPage, r.widgetPool, r.App.PlaybackManager, r.App.ServerManager.Server, r.App.ArtistInfoManager, r.App.ImageManager, r.Controller)
 	case controller.Artists:
 		return NewArtistsPage(&r.App.Config.ArtistsPage, r.widgetPool, r.Controller, r.App.PlaybackManager, r.App.ServerManager.Server, r.App.ImageManager)
 	case controller.Favorites:

--- a/ui/dialogs/settingsdialog.go
+++ b/ui/dialogs/settingsdialog.go
@@ -795,6 +795,7 @@ func (s *SettingsDialog) createAdvancedTab() *container.TabItem {
 	multi := widget.NewCheckWithData(lang.L("Allow multiple app instances"), binding.BindBool(&s.config.Application.AllowMultiInstance))
 	update := widget.NewCheckWithData(lang.L("Automatically check for updates"), binding.BindBool(&s.config.Application.EnableAutoUpdateChecker))
 	lrclib := widget.NewCheckWithData(lang.L("Enable LrcLib lyrics fetcher"), binding.BindBool(&s.config.Application.EnableLrcLib))
+	extArtistInfo := widget.NewCheckWithData(lang.L("Enable Deezer/Wikipedia artist info"), binding.BindBool(&s.config.Application.EnableExternalArtistInfo))
 
 	threeDigitValidator := func(text, selText string, r rune) bool {
 		return unicode.IsDigit(r) && len(text)-len(selText) < 3
@@ -836,6 +837,7 @@ func (s *SettingsDialog) createAdvancedTab() *container.TabItem {
 		multi,
 		update,
 		lrclib,
+		extArtistInfo,
 		osMediaAPIs,
 		preventScreensaver,
 		imgCacheCfg,


### PR DESCRIPTION
## Summary

As discussed in #826, this PR extracts the Deezer/Wikipedia artist info fetching into a shared fallback available for **all server types** (Subsonic, Jellyfin, and future MPD), following the same pattern as the existing LrcLib lyrics integration.

- **`ArtistInfoFetcher`** — fetches artist images from Deezer and biographies from Wikipedia (with language preference and in-memory caching)
- **`ArtistInfoManager`** — tries the server's native `GetArtistInfo` first, then fills in missing biography/image data from external sources
- **Settings checkbox** — "Enable Deezer/Wikipedia artist info" in Advanced tab lets users disable external network requests

### How it works

When a server returns incomplete artist info (empty biography or no image URL), the manager transparently queries Deezer and Wikipedia to fill the gaps. Servers that already return complete metadata (e.g. Subsonic with Last.fm configured) will see no additional network requests.

### Files changed

| File | Change |
|------|--------|
| `backend/artistinfofetcher.go` | New — Deezer/Wikipedia fetcher (extracted from MPD PR) |
| `backend/artistinfomanager.go` | New — fallback manager (server first, then external) |
| `backend/config.go` | Add `EnableExternalArtistInfo` config field |
| `backend/app.go` | Wire `ArtistInfoManager` into App lifecycle |
| `ui/dialogs/settingsdialog.go` | Add checkbox in Advanced tab |
| `ui/browsing/artistpage.go` | Use `ArtistInfoManager` instead of direct `mp.GetArtistInfo` |
| `ui/browsing/router.go` | Pass `ArtistInfoManager` to artist page |

### Relation to #826

This is the prerequisite PR mentioned in the [review comment](https://github.com/dweymouth/supersonic/pull/826#issuecomment-2828060588). Once merged, the MPD PR (#826) can be rebased to use the shared fetcher instead of its own copy, reducing its line count.