### PR TITLE
Fix #881: discography sort button regression on Artist page

### DIFF
--- a/ui/browsing/artistpage.go
+++ b/ui/browsing/artistpage.go
@@ -342,7 +342,7 @@ func (a *ArtistPage) load() {
 }
 
 func (a *ArtistPage) showAlbumGrid(reSort bool) {
-	if a.activeView == 0 && a.albumGrid != nil {
+	if a.activeView == 0 && (a.albumGrid != nil || a.groupedReleases != nil) && !reSort {
 		return // already showing album grid
 	}
 	a.activeView = 0


### PR DESCRIPTION
## Summary

- The sort button on the Artist page discography tab had no effect — clicking a sort option did nothing
- Root cause: a early-return guard added in 13cb672 (`showAlbumGrid`) did not check the `reSort` flag, so `showAlbumGrid(true /*reSort*/)` called from the sort button callback returned immediately when the discography view was already active
- Fix: add `&& !reSort` to the guard condition; also extend it to cover the `groupedReleases` case for consistency

## Test plan

- [x] Open an artist page, switch to the Discography tab
- [x] Change the sort order — albums should reorder immediately
- [x] Verify all three sort options work: Year (ascending), Year (descending), Name (A-Z)
- [ ] Verify the same on an artist whose discography uses the GroupedReleases layout (artist with EPs/singles/compilations mixed in, ≤50 total releases)

🤖 Generated with [Claude Code](https://claude.com/claude-code)