### PR TITLE
Fix #895: Fix crash on track change and scrobble

### DIFF
--- a/backend/playbackengine.go
+++ b/backend/playbackengine.go
@@ -262,6 +262,7 @@ func (p *playbackEngine) getPlayQueueLength() int {
 }
 
 func (p *playbackEngine) clearPlayQueue() {
+	p.checkScrobble()
 	p.player.Stop(false)
 	p.nowPlayingIdx = -1
 	p.playQueue = nil

--- a/backend/playbackengine.go
+++ b/backend/playbackengine.go
@@ -576,12 +576,13 @@ func (p *playbackEngine) LoadItems(items []mediaprovider.MediaItem, insertQueueM
 	return p.doLoaditems(newItems, insertQueueMode, shuffle)
 }
 
-// Load items into the play queue.
-// If replacing the current queue (!appendToQueue), playback will be stopped.
+// Load items into the play queue and play the track at idx.
+// Replaces the playQueue, shuffledPlayQueue, or both
 func (p *playbackEngine) LoadItemsAndPlayAtIdx(items []mediaprovider.MediaItem, shuffle bool, idx int) error {
 	newItems := deepCopyMediaItemSlice(items)
 
 	if p.shuffle || shuffle {
+		p.clearPlayQueue()
 		rand.Shuffle(len(newItems), func(i, j int) {
 			newItems[i], newItems[j] = newItems[j], newItems[i]
 		})


### PR DESCRIPTION
After digging a bit, the reason this crash doesn't happen if shuffle is disabled is because doLoaditems(...) calls clearPlayQueue(). 
I added this to the shuffle-branch as well and it looks like scrobbling works as intended again. 