### PR TITLE
Fix frozen display when returning to window on inactive Wayland workspace

### DIFF
--- a/main.go
+++ b/main.go
@@ -112,6 +112,14 @@ func main() {
 	myApp.OnExit = util.FyneDoFunc(mainWindow.Quit)
 	myApp.OnReloadTheme = util.FyneDoFunc(mainWindow.ReloadTheme)
 
+	if runtime.GOOS == "linux" {
+		// On Wayland, the render loop stalls when the window is on an inactive
+		// workspace. Force a refresh when focus returns to update the display.
+		fyneApp.Lifecycle().SetOnEnteredForeground(func() {
+			mainWindow.Canvas().Refresh(mainWindow.Canvas().Content())
+		})
+	}
+
 	if runtime.GOOS == "windows" {
 		windowStartupTasks := sync.OnceFunc(func() {
 			mainWindow.Window.(driver.NativeWindow).RunNative(func(ctx any) {


### PR DESCRIPTION
Would mitigate https://github.com/dweymouth/supersonic/issues/560 until upstream issue https://github.com/fyne-io/fyne/issues/6080 is resolved by forcing a canvas refresh when the window becomes active again.

Ultimately this really _should_ be fixed upstream but I tested this and it's something that could be done here today.

### Testing

Testing is a little tricker--I can't demonstrate that it _doesn't_ freeze since it's a bit random already. It sometimes takes a while to freeze.

So, this demonstrates the behavior I was seeing **before** and how I typically have been fixing it by forcing a window resize. After this change this stopped happening in the time that I tested.

https://github.com/user-attachments/assets/ae9d2eb3-1a2f-432d-9b11-1697a7b5e596
