### PR TITLE
Fix keyring unlock blocking the Fyne event loop on startup

### DIFF
--- a/ui/controller/serverconnection.go
+++ b/ui/controller/serverconnection.go
@@ -49,14 +49,24 @@ func (m *Controller) PromptForFirstServer() {
 
 // DoConnectToServerWorkflow does the workflow for connecting to the last active server on startup
 func (c *Controller) DoConnectToServerWorkflow(server *backend.ServerConfig) {
-	pass, err := c.App.ServerManager.GetServerPassword(server.ID)
-	if err != nil {
-		log.Printf("error getting password from keyring: %v", err)
-		c.PromptForLoginAndConnect()
-		return
-	}
+	// GetServerPassword may block on keyring unlock (showing a system dialog),
+	// so run it in a goroutine to avoid freezing the Fyne event loop.
+	go func() {
+		pass, err := c.App.ServerManager.GetServerPassword(server.ID)
+		if err != nil {
+			log.Printf("error getting password from keyring: %v", err)
+			fyne.Do(c.PromptForLoginAndConnect)
+			return
+		}
 
-	// try connecting to last used server - set up cancelable modal dialog
+		// Password retrieved; show the dialog and connect from the Fyne thread
+		fyne.Do(func() {
+			c.doConnectWithPassword(server, pass)
+		})
+	}()
+}
+
+func (c *Controller) doConnectWithPassword(server *backend.ServerConfig, pass string) {
 	canceled := false
 	ctx, cancel := context.WithCancel(context.Background())
 	dlg := dialog.NewCustom(lang.L("Connecting"), lang.L("Cancel"),


### PR DESCRIPTION
Fixes: https://github.com/dweymouth/supersonic/issues/899

GetServerPassword can block while the system keyring daemon shows its unlock dialog. Calling it synchronously on the Fyne main thread froze the event loop, causing Wayland compositors to hide the window or the our application crashes entirely.

Moves the keyring lookup into a goroutine and dispatches back to the Fyne thread to show the connecting dialog and attempt the connection.

FWIW I get mixed behavior on this issue--sometimes the entire application dies and other times the window dies but the taskbar icon stays. It could be that that icon, when clicked, can bring it back but I have a separate issue I'm going to investigate later where that icon doesn't do anything on my system.

### Testing

https://github.com/user-attachments/assets/9715e4b6-bd20-4125-8967-3cda2d6d8af1