### PR TITLE
Scroll artist bio

### DIFF
--- a/ui/browsing/artistpage.go
+++ b/ui/browsing/artistpage.go
@@ -587,7 +587,8 @@ type ArtistPageHeader struct {
 	artistImage           *widgets.ImagePlaceholder
 	artistImageID         string
 	titleDisp             *widget.RichText
-	biographyDisp         *widgets.MaxRowsLabel
+	biographyDisp         *widget.Label
+	biographyScroll       *container.Scroll
 	similarArtists        *fyne.Container
 	favoriteBtn           *widgets.FavoriteButton
 	playBtn               *widget.Button
@@ -602,11 +603,17 @@ type ArtistPageHeader struct {
 func NewArtistPageHeader(page *ArtistPage) *ArtistPageHeader {
 	// due to widget reuse a.artistPage can change so page MUST NOT
 	// be directly captured in a closure throughout this function!
+	biographyText := widget.NewLabel(lang.L(artistBioNotAvailableKey))
+
+	scroll := container.NewScroll(biographyText)
+	scroll.SetMinSize(fyne.NewSize(0, 100))
+
 	a := &ArtistPageHeader{
-		artistPage:     page,
-		titleDisp:      widget.NewRichTextWithText(""),
-		biographyDisp:  widgets.NewMaxRowsLabel(5, lang.L(artistBioNotAvailableKey)),
-		similarArtists: container.NewHBox(),
+		artistPage:      page,
+		titleDisp:       widget.NewRichTextWithText(""),
+		biographyDisp:   biographyText,
+		biographyScroll: scroll,
+		similarArtists:  container.NewHBox(),
 	}
 	a.titleDisp.Segments[0].(*widget.TextSegment).Style = widget.RichTextStyle{
 		SizeName: theme.SizeNameHeadingText,
@@ -655,7 +662,6 @@ func NewArtistPageHeader(page *ArtistPage) *ArtistPageHeader {
 	// shareMenuItem.Disabled = !canShareArtists
 
 	a.biographyDisp.Wrapping = fyne.TextWrapWord
-	a.biographyDisp.Truncation = fyne.TextTruncateEllipsis
 	a.collapseBtn = widgets.NewHeaderCollapseButton(func() {
 		a.Compact = !a.Compact
 		a.artistPage.cfg.CompactHeader = a.Compact
@@ -771,8 +777,10 @@ func (a *ArtistPageHeader) Refresh() {
 	a.similarArtists.Hidden = a.Compact
 	a.collapseBtn.Collapsed = a.Compact
 	if a.Compact {
+		a.biographyScroll.Hide()
 		a.artistImage.SetMinSize(fyne.NewSquareSize(myTheme.CompactHeaderImageSize))
 	} else {
+		a.biographyScroll.Show()
 		a.artistImage.SetMinSize(fyne.NewSquareSize(myTheme.HeaderImageSize))
 	}
 	a.BaseWidget.Refresh()
@@ -816,7 +824,7 @@ func (a *ArtistPageHeader) createContainer() {
 			container.NewBorder(nil, nil, a.artistImage, nil,
 				container.NewVBox(
 					container.New(layout.NewCustomPaddedVBoxLayout(theme.Padding()-10),
-						a.titleDisp, a.biographyDisp, a.similarArtists),
+						a.titleDisp, a.biographyScroll, util.NewVSpace(10), a.similarArtists),
 					btnContainer),
 			),
 			container.NewVBox(container.NewHBox(layout.NewSpacer(), a.collapseBtn)),


### PR DESCRIPTION
I added the scroll on the artist biography about the issue https://github.com/dweymouth/supersonic/issues/803

I have removed the ellipsis to show the full text and added a vertical space. It works on full screen or other sizes, and hides with the compact.

<img width="793" height="315" alt="image" src="https://github.com/user-attachments/assets/1c6b6d29-9ef8-43a3-b623-92ef0bf5db2a" />


