### PR TITLE
Skip autoplay when a radio station is playing

### DIFF
--- a/backend/playbackmanager.go
+++ b/backend/playbackmanager.go
@@ -805,6 +805,9 @@ func (p *PlaybackManager) enqueueAutoplayTracks() {
 	if nowPlaying == nil {
 		return
 	}
+	if nowPlaying.Metadata().Type == mediaprovider.MediaItemTypeRadioStation {
+		return
+	}
 
 	s := p.engine.sm.Server
 	if s == nil {


### PR DESCRIPTION
## Summary

- Autoplay (similar songs) is skipped when the currently playing item is a radio station
- Radio streams have no meaningful end-of-queue to extend, so the setting should not apply to them

## Changes

Added an early return in `enqueueAutoplayTracks` that checks if the now-playing item is a `MediaItemTypeRadioStation` and exits without enqueueing anything.