### PR TITLE
Add "All Tracks" option to Startup page

### DIFF
--- a/backend/config.go
+++ b/backend/config.go
@@ -197,7 +197,7 @@ type Config struct {
 	PeakMeter        PeakMeterConfig
 }
 
-var SupportedStartupPages = []string{"Albums", "Favorites", "Playlists", "Artists"}
+var SupportedStartupPages = []string{"Albums", "Favorites", "Playlists", "Artists", "All Tracks"}
 
 func DefaultConfig(appVersionTag string) *Config {
 	return &Config{

--- a/ui/controller/routes.go
+++ b/ui/controller/routes.go
@@ -66,6 +66,10 @@ func AlbumRoute(albumID string) Route {
 	return Route{Page: Album, Arg: albumID}
 }
 
+func AllTracksRoute() Route {
+	return Route{Page: Tracks}
+}
+
 func FavoritesRoute() Route {
 	return Route{Page: Favorites}
 }

--- a/ui/mainwindow.go
+++ b/ui/mainwindow.go
@@ -281,6 +281,8 @@ func (m *MainWindow) ReloadTheme() {
 
 func (m *MainWindow) StartupPage() controller.Route {
 	switch m.App.Config.Application.StartupPage {
+	case "All Tracks":
+		return controller.AllTracksRoute()
 	case "Artists":
 		return controller.ArtistsRoute()
 	case "Favorites":


### PR DESCRIPTION
I prefer to shuffle all available tracks at launch via Play Random button in All Tracks page. This PR saves an extra click required to go into "All Tracks" page at start. This PR was fully tested.