### PR TITLE
fix: clear stale cover art and backgrounds on tracks without art

### DIFF
--- a/ui/browsing/nowplayingpage.go
+++ b/ui/browsing/nowplayingpage.go
@@ -330,6 +330,25 @@ func (a *NowPlayingPage) onImageLoaded(img image.Image, err error) {
 
 	fyne.Do(func() { a.card.SetCoverImage(img) })
 	if img == nil {
+		if a.conf.UseBackgroundImage {
+			fyne.Do(func() {
+				if !a.backgroundImgA.Hidden {
+					a.backgroundImgA.Hide()
+				}
+				if !a.backgroundImgB.Hidden {
+					a.backgroundImgB.Hide()
+				}
+			})
+		} else {
+			if a.backgroundGradient.StartColor != color.Transparent {
+				anim := canvas.NewColorRGBAAnimation(
+					a.backgroundGradient.StartColor, color.Transparent, myTheme.AnimationDurationMedium, func(c color.Color) {
+						a.backgroundGradient.StartColor = c
+						a.backgroundGradient.Refresh()
+					})
+				anim.Start()
+			}
+		}
 		return
 	}
 

--- a/ui/util/thumbnailloader.go
+++ b/ui/util/thumbnailloader.go
@@ -52,6 +52,7 @@ func (i *ThumbnailLoader) Load(coverID string) {
 		fyne.Do(func() {
 			if err != nil {
 				log.Printf("Error loading cover image: %s", err.Error())
+				i.callOnLoaded(nil)
 			} else {
 				i.callOnLoaded(img)
 			}


### PR DESCRIPTION
**Description:**
Fixes a bug where the previous track's artwork persists in the bottom player and Now Playing page background when switching to a track that lacks album art.

**Demonstration of Bug:**

https://github.com/user-attachments/assets/3d38f7cb-4579-404e-9f75-f8b5f7dfc2ec

**Changes:**

- `ui/util/thumbnailloader.go`: Calls `callOnLoaded(nil)` on error. This fixes the bottom player silently retaining stale images by ensuring it receives a callback to clear its display state when a thumbnail fails to load.
- `ui/browsing/nowplayingpage.go`: Handles the `nil` state explicitly instead of returning early (now hides the blurred background widgets or animates the gradient to transparent)

**Demonstration of Fix:**

https://github.com/user-attachments/assets/110fc7b1-919e-4f72-8640-5b610c64b29e

I forgot to record a video but this also works for the gradients.

---

Tested with my Jellyfin server.