### PR TITLE
fix(ci): fix VapourSynth dylib file existence check on macOS

### DIFF
--- a/scripts/copy_python_dep_osx.sh
+++ b/scripts/copy_python_dep_osx.sh
@@ -1,5 +1,15 @@
 #!/bin/sh
 
-PYTHON_PATH=$(otool -L ./Supersonic.app/Contents/Frameworks/libvapoursynth-script.0.dylib | grep 'Python' | awk '{print $1}')
-install_name_tool -change "$PYTHON_PATH" "@executable_path/../Frameworks/Python" "./Supersonic.app/Contents/Frameworks/libvapoursynth-script.0.dylib"
-cp "$PYTHON_PATH" ./Supersonic.app/Contents/Frameworks
+VAPOURSYNTH_LIB=./Supersonic.app/Contents/Frameworks/libvapoursynth-script.0.dylib
+
+# Check if VapourSynth library exists before processing
+if [ ! -f "$VAPOURSYNTH_LIB" ]; then
+    echo "VapourSynth library not found, skipping Python dependency copy"
+    exit 0
+fi
+
+PYTHON_PATH=$(otool -L "$VAPOURSYNTH_LIB" | grep 'Python' | awk '{print $1}')
+if [ -n "$PYTHON_PATH" ]; then
+    install_name_tool -change "$PYTHON_PATH" "@executable_path/../Frameworks/Python" "$VAPOURSYNTH_LIB"
+    cp "$PYTHON_PATH" ./Supersonic.app/Contents/Frameworks
+fi


### PR DESCRIPTION
## Description

Fix VapourSynth dylib file existence check in macOS build script.

### Problem

The original script used `otool -L` to find the Python path in the VapourSynth dylib, but didn't verify the file exists before attempting to copy it. This could cause the CI build to fail silently or with a confusing error.

### Fix

- Add file existence check before attempting to copy the VapourSynth dylib
- Improve error handling in the build script

### Changes

- `scripts/copy_python_dep_osx.sh`: Add file existence check and improve error handling
