### PR TITLE
Hide macOS Dock icon when closing to system tray

### DIFF
--- a/ui/app_delegate_darwin.go
+++ b/ui/app_delegate_darwin.go
@@ -9,6 +9,7 @@ void dockMenuBegin();
 void dockMenuAddItem(const char* title, int index);
 void dockMenuAddSeparator();
 void dockMenuCommit();
+void setDockIconVisible(int visible);
 */
 import "C"
 
@@ -28,6 +29,14 @@ func isRealQuit() bool {
 	return darwinQuitting
 }
 
+func setAppDockIconVisible(visible bool) {
+	cVisible := C.int(0)
+	if visible {
+		cVisible = 1
+	}
+	C.setDockIconVisible(cVisible)
+}
+
 func installReopenHandler(w fyne.Window) {
 	darwinAppDelegateReopenWindow = w
 	C.installReopenDelegate()
@@ -39,7 +48,10 @@ func appReopened() {
 		return
 	}
 	go func() {
-		fyne.Do(darwinAppDelegateReopenWindow.Show)
+		fyne.Do(func() {
+			setAppDockIconVisible(true)
+			darwinAppDelegateReopenWindow.Show()
+		})
 	}()
 }
 

--- a/ui/app_delegate_darwin.m
+++ b/ui/app_delegate_darwin.m
@@ -77,6 +77,12 @@ void installReopenDelegate(void) {
     [NSApp setDelegate:d];
 }
 
+void setDockIconVisible(int visible) {
+    [NSApp setActivationPolicy:visible
+        ? NSApplicationActivationPolicyRegular
+        : NSApplicationActivationPolicyAccessory];
+}
+
 void dockMenuBegin(void) {
     if (!dockMenuTarget) {
         dockMenuTarget = [DockMenuTarget new];

--- a/ui/app_delegate_other.go
+++ b/ui/app_delegate_other.go
@@ -11,5 +11,8 @@ func isRealQuit() bool {
 	return false
 }
 
+func setAppDockIconVisible(visible bool) {
+}
+
 func installDockMenu(menu *fyne.Menu) {
 }

--- a/ui/mainwindow.go
+++ b/ui/mainwindow.go
@@ -187,7 +187,7 @@ func NewMainWindow(fyneApp fyne.App, appName, displayAppName, appVersion string,
 	m.Window.SetCloseIntercept(func() {
 		m.SaveWindowSettings()
 		if (runtime.GOOS == "darwin" && !isRealQuit()) || (app.Config.Application.CloseToSystemTray && m.HaveSystemTray()) {
-			m.Window.Hide()
+			m.hideWindow()
 		} else {
 			m.Window.Close()
 		}
@@ -417,6 +417,18 @@ func (m *MainWindow) SetupSystemTrayMenu(appName string, fyneApp fyne.App) {
 	}
 }
 
+func (m *MainWindow) showWindow() {
+	setAppDockIconVisible(true)
+	m.Window.Show()
+}
+
+func (m *MainWindow) hideWindow() {
+	m.Window.Hide()
+	if runtime.GOOS == "darwin" && m.App.Config.Application.CloseToSystemTray && m.HaveSystemTray() {
+		setAppDockIconVisible(false)
+	}
+}
+
 func (m *MainWindow) createSystemTrayAndDockMenu(includeShowAndHide bool) *fyne.Menu {
 	menu := fyne.NewMenu("",
 		fyne.NewMenuItem(fmt.Sprintf("%s/%s", lang.L("Play"), lang.L("Pause")), func() {
@@ -443,8 +455,8 @@ func (m *MainWindow) createSystemTrayAndDockMenu(includeShowAndHide bool) *fyne.
 	)
 	if includeShowAndHide {
 		menu.Items = append(menu.Items, fyne.NewMenuItemSeparator())
-		menu.Items = append(menu.Items, fyne.NewMenuItem(lang.L("Show"), m.Window.Show))
-		menu.Items = append(menu.Items, fyne.NewMenuItem(lang.L("Hide"), m.Window.Hide))
+		menu.Items = append(menu.Items, fyne.NewMenuItem(lang.L("Show"), m.showWindow))
+		menu.Items = append(menu.Items, fyne.NewMenuItem(lang.L("Hide"), m.hideWindow))
 	}
 	return menu
 }
@@ -525,7 +537,7 @@ func (m *MainWindow) addShortcuts() {
 	})
 	m.Canvas().AddShortcut(&shortcuts.ShortcutCloseWindow, func(_ fyne.Shortcut) {
 		if runtime.GOOS == "darwin" || (m.App.Config.Application.CloseToSystemTray && m.HaveSystemTray()) {
-			m.Window.Hide()
+			m.hideWindow()
 		}
 	})
 


### PR DESCRIPTION
## Summary

- hide the macOS Dock icon when the main window is hidden and both system tray options are enabled
- restore the regular activation policy before showing or reopening the window
- route tray menu and Cmd+W show/hide actions through the same behavior
- keep existing behavior unchanged on other platforms and when close-to-tray is disabled

This makes **Enable system tray** + **Close to system tray** behave like a menu-bar app on macOS instead of leaving a permanent Dock icon.

Related to #140 and the reopen handling added in #878.

## Testing

- `go test ./...`
- built and ran a local macOS app bundle on Apple Silicon
- manually verified that closing the window removes the Dock icon while playback continues
- manually verified that **Show** from the menu bar restores the window and Dock icon
