### PR TITLE
fix(playback): resume interrupted streams

### DIFF
--- a/backend/playbackengine.go
+++ b/backend/playbackengine.go
@@ -66,10 +66,11 @@ type playbackEngine struct {
 	audiocache    *AudioCache
 	player        player.BasePlayer
 
-	playTimeStopwatch   util.Stopwatch
-	curTrackDuration    float64
-	latestTrackPosition float64 // cleared by checkScrobble
-	callbacksDisabled   bool
+	playTimeStopwatch         util.Stopwatch
+	curTrackDuration          float64
+	latestTrackPosition       float64 // furthest position reached; cleared by checkScrobble
+	lastObservedTrackPosition float64
+	callbacksDisabled         bool
 
 	playQueue         []mediaprovider.MediaItem
 	shuffledPlayQueue []mediaprovider.MediaItem
@@ -81,9 +82,10 @@ type playbackEngine struct {
 
 	pauseAfterCurrent bool // flag to pause playback after current track ends
 
-	// flags for handleOnTrackChange / handleOnStopped callbacks - reset to false in the callbacks
-	wasStopped       bool // true iff player was stopped before handleOnTrackChange invocation
-	alreadyScrobbled bool // true iff the previously-playing track was already scrobbled
+	// flags for player callbacks
+	wasStopped               bool // true iff player was stopped before handleOnTrackChange invocation
+	alreadyScrobbled         bool // true iff the previously-playing track was already scrobbled
+	resumeAfterPlaybackError bool
 
 	// if >= 0, track number that was requested by PlayTrackAt
 	// onTrackChange callback should set nowPlayingIdx to this,
@@ -177,6 +179,9 @@ func (p *playbackEngine) registerPlayerCallbacks(pl player.BasePlayer) {
 		p.reportPlayback(seekState)
 	})
 	pl.OnStopped(p.handleOnStopped)
+	if ep, ok := pl.(player.PlaybackErrorPlayer); ok {
+		ep.OnPlaybackError(p.handlePlaybackError)
+	}
 	pl.OnPaused(func() {
 		p.playTimeStopwatch.Stop()
 		p.stopPollTimePos()
@@ -197,6 +202,9 @@ func (p *playbackEngine) unregisterPlayerCallbacks(pl player.BasePlayer) {
 	pl.OnStopped(nil)
 	pl.OnSeek(nil)
 	pl.OnTrackChange(nil)
+	if ep, ok := pl.(player.PlaybackErrorPlayer); ok {
+		ep.OnPlaybackError(nil)
+	}
 }
 
 func (p *playbackEngine) SetPlayer(pl player.BasePlayer) error {
@@ -270,6 +278,7 @@ func (p *playbackEngine) getPlayQueueLength() int {
 
 func (p *playbackEngine) clearPlayQueue() {
 	p.checkScrobble()
+	p.resumeAfterPlaybackError = false
 	p.player.Stop(false)
 	p.nowPlayingIdx = -1
 	p.playQueue = nil
@@ -523,6 +532,7 @@ func (p *playbackEngine) IsSeeking() bool {
 }
 
 func (p *playbackEngine) Stop() error {
+	p.resumeAfterPlaybackError = false
 	if p.pendingLoadPaused {
 		p.pendingLoadPaused = false
 		p.pendingLoadStartTime = 0
@@ -746,7 +756,7 @@ func (p *playbackEngine) RemoveTracksFromQueue(idxs []int) {
 		newPlayQueue := make([]mediaprovider.MediaItem, 0, p.getPlayQueueLength()-len(idxs))
 		for _, tr := range p.getPlayQueue() {
 			if slices.Contains(ids, tr.Metadata().ID) {
-				//remove id from id list, handles having the same track present multiple times in playQueue
+				// remove id from id list, handles having the same track present multiple times in playQueue
 				idx := slices.Index(ids, tr.Metadata().ID)
 				ids = slices.Delete(ids, idx, idx+1)
 			} else {
@@ -886,6 +896,8 @@ func (p *playbackEngine) cacheNextTracks() {
 }
 
 func (p *playbackEngine) handleOnTrackChange() {
+	p.resumeAfterPlaybackError = false
+	p.lastObservedTrackPosition = 0
 	// scrobble the previous song if needed
 	if !p.alreadyScrobbled {
 		p.checkScrobble()
@@ -921,15 +933,36 @@ func (p *playbackEngine) handleOnTrackChange() {
 		p.Pause()
 		p.SetPauseAfterCurrent(false)
 	}
+}
 
+func (p *playbackEngine) handlePlaybackError(err error) {
+	log.Printf("Playback error: %v", err)
+	if p.isRadio || p.nowPlayingIdx < 0 {
+		return
+	}
+	if position := p.PlaybackStatus().TimePos; position > 0 {
+		p.lastObservedTrackPosition = position
+	}
+	p.resumeAfterPlaybackError = true
 }
 
 func (p *playbackEngine) handleOnStopped() {
 	p.playTimeStopwatch.Stop()
+	p.stopPollTimePos()
+
+	if p.resumeAfterPlaybackError {
+		p.resumeAfterPlaybackError = false
+		p.pendingLoadPaused = true
+		p.pendingLoadStartTime = p.lastObservedTrackPosition
+		p.handleTimePosUpdate(false)
+		p.invokeNoArgCallbacks(p.onPaused)
+		p.reportPlayback("paused")
+		return
+	}
+
 	if !p.alreadyScrobbled {
 		p.checkScrobble()
 	}
-	p.stopPollTimePos()
 	p.handleTimePosUpdate(false)
 	p.invokeOnSongChangeCallbacks()
 	p.invokeNoArgCallbacks(p.onStopped)
@@ -1194,6 +1227,9 @@ func (p *playbackEngine) handleTimePosUpdate(seeked bool) {
 	}
 	if p.callbacksDisabled {
 		return
+	}
+	if s.TimePos >= 0 {
+		p.lastObservedTrackPosition = s.TimePos
 	}
 	if s.TimePos > p.latestTrackPosition {
 		p.latestTrackPosition = s.TimePos

--- a/backend/playbackengine_test.go
+++ b/backend/playbackengine_test.go
@@ -1,0 +1,166 @@
+package backend
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/supersonic-app/supersonic/backend/mediaprovider"
+	"github.com/supersonic-app/supersonic/backend/player"
+)
+
+type networkErrorPlayer struct {
+	player.BasePlayerCallbackImpl
+	status        player.Status
+	playedURL     string
+	playStartTime float64
+}
+
+func (p *networkErrorPlayer) Continue() error                                           { return nil }
+func (p *networkErrorPlayer) Pause() error                                              { return nil }
+func (p *networkErrorPlayer) SeekSeconds(float64) error                                 { return nil }
+func (p *networkErrorPlayer) IsSeeking() bool                                           { return false }
+func (p *networkErrorPlayer) SetVolume(int) error                                       { return nil }
+func (p *networkErrorPlayer) GetVolume() int                                            { return 50 }
+func (p *networkErrorPlayer) GetStatus() player.Status                                  { return p.status }
+func (p *networkErrorPlayer) Destroy()                                                  {}
+func (p *networkErrorPlayer) SetNextFile(string, mediaprovider.MediaItemMetadata) error { return nil }
+
+func (p *networkErrorPlayer) Stop(bool) error {
+	p.status.State = player.Stopped
+	p.InvokeOnStopped()
+	return nil
+}
+
+func (p *networkErrorPlayer) PlayFile(url string, metadata mediaprovider.MediaItemMetadata, startTime float64) error {
+	p.playedURL = url
+	p.playStartTime = startTime
+	p.status = player.Status{State: player.Playing, TimePos: startTime, Duration: metadata.Duration.Seconds()}
+	p.InvokeOnTrackChange()
+	return nil
+}
+
+type streamURLProvider struct {
+	mediaprovider.MediaProvider
+	reports chan string
+}
+
+func (s *streamURLProvider) GetStreamURL(trackID string, _ *mediaprovider.TranscodeSettings, _ bool) (string, error) {
+	return "https://music.example/stream/" + trackID, nil
+}
+
+func (s *streamURLProvider) ReportPlayback(_ string, _ int64, state string) error {
+	s.reports <- state
+	return nil
+}
+
+func newNetworkErrorEngine(p *networkErrorPlayer) (*playbackEngine, []*mediaprovider.Track) {
+	tracks := []*mediaprovider.Track{
+		{ID: "first", Duration: 4 * time.Minute},
+		{ID: "interrupted", Duration: 5 * time.Minute},
+	}
+	items := []mediaprovider.MediaItem{tracks[0], tracks[1]}
+	engine := &playbackEngine{
+		ctx:                       context.Background(),
+		sm:                        &ServerManager{Server: &streamURLProvider{reports: make(chan string, 4)}},
+		player:                    p,
+		playbackCfg:               &PlaybackConfig{},
+		scrobbleCfg:               &ScrobbleConfig{},
+		transcodeCfg:              &TranscodingConfig{},
+		playQueue:                 items,
+		nowPlayingIdx:             1,
+		pendingTrackChangeNum:     -1,
+		curTrackDuration:          tracks[1].Duration.Seconds(),
+		latestTrackPosition:       180,
+		lastObservedTrackPosition: 70,
+	}
+	engine.registerPlayerCallbacks(p)
+	return engine, tracks
+}
+
+func TestPlaybackErrorRetriesCurrentTrackAtLastObservedPosition(t *testing.T) {
+	p := &networkErrorPlayer{status: player.Status{State: player.Playing, TimePos: 70, Duration: 300}}
+	engine, tracks := newNetworkErrorEngine(p)
+
+	p.InvokeOnPlaybackError(errors.New("network connection lost"))
+	p.status = player.Status{State: player.Stopped}
+	p.InvokeOnStopped()
+
+	if got := engine.NowPlayingIndex(); got != 1 {
+		t.Fatalf("NowPlayingIndex after playback error = %d, want 1", got)
+	}
+	status := engine.PlaybackStatus()
+	if status.State != player.Paused || status.TimePos != 70 {
+		t.Fatalf("PlaybackStatus after playback error = %+v, want paused at 70 seconds", status)
+	}
+	provider := engine.sm.Server.(*streamURLProvider)
+	select {
+	case state := <-provider.reports:
+		if state != "paused" {
+			t.Fatalf("reported playback state = %q, want paused", state)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for paused playback report")
+	}
+
+	if err := engine.Continue(); err != nil {
+		t.Fatal(err)
+	}
+	if want := "https://music.example/stream/" + tracks[1].ID; p.playedURL != want {
+		t.Fatalf("retried URL = %q, want %q", p.playedURL, want)
+	}
+	if p.playStartTime != 70 {
+		t.Fatalf("retry start time = %v, want 70", p.playStartTime)
+	}
+	if got := len(engine.getActivePlayQueue()); got != 2 {
+		t.Fatalf("queue length after retry = %d, want 2", got)
+	}
+}
+
+func TestRequestedStopResetsCurrentTrack(t *testing.T) {
+	p := &networkErrorPlayer{status: player.Status{State: player.Playing, TimePos: 70, Duration: 300}}
+	engine, _ := newNetworkErrorEngine(p)
+
+	if err := engine.Stop(); err != nil {
+		t.Fatal(err)
+	}
+	if got := engine.NowPlayingIndex(); got != -1 {
+		t.Fatalf("NowPlayingIndex after requested stop = %d, want -1", got)
+	}
+	if engine.pendingLoadPaused {
+		t.Fatal("requested stop must not create resumable playback state")
+	}
+}
+
+func TestStoppedWithoutPlaybackErrorDoesNotCreateResumeState(t *testing.T) {
+	p := &networkErrorPlayer{status: player.Status{State: player.Playing, TimePos: 70, Duration: 300}}
+	engine, _ := newNetworkErrorEngine(p)
+
+	p.status = player.Status{State: player.Stopped}
+	p.InvokeOnStopped()
+
+	if got := engine.NowPlayingIndex(); got != -1 {
+		t.Fatalf("NowPlayingIndex after normal stop = %d, want -1", got)
+	}
+	if engine.pendingLoadPaused {
+		t.Fatal("normal stop must not create resumable playback state")
+	}
+}
+
+func TestRequestedStopCancelsPendingPlaybackErrorResume(t *testing.T) {
+	p := &networkErrorPlayer{status: player.Status{State: player.Playing, TimePos: 70, Duration: 300}}
+	engine, _ := newNetworkErrorEngine(p)
+
+	p.InvokeOnPlaybackError(errors.New("network connection lost"))
+	if err := engine.Stop(); err != nil {
+		t.Fatal(err)
+	}
+
+	if engine.pendingLoadPaused {
+		t.Fatal("requested stop must cancel pending playback error recovery")
+	}
+	if got := engine.NowPlayingIndex(); got != -1 {
+		t.Fatalf("NowPlayingIndex after requested stop = %d, want -1", got)
+	}
+}

--- a/backend/player/mpv/endfile.go
+++ b/backend/player/mpv/endfile.go
@@ -1,0 +1,51 @@
+package mpv
+
+/*
+#cgo pkg-config: mpv
+#include <mpv/client.h>
+
+static int supersonic_end_file_reason(void *data) {
+	if (data == NULL) {
+		return -1;
+	}
+	return ((mpv_event_end_file *)data)->reason;
+}
+
+static int supersonic_end_file_error(void *data) {
+	if (data == NULL) {
+		return 0;
+	}
+	return ((mpv_event_end_file *)data)->error;
+}
+*/
+import "C"
+
+import (
+	"errors"
+	"fmt"
+	"unsafe"
+
+	"github.com/supersonic-app/supersonic/backend/player"
+)
+
+const prematureEOFToleranceSeconds = 2
+
+func playbackErrorFromEndFileEvent(data unsafe.Pointer, status player.Status) error {
+	reason := C.supersonic_end_file_reason(data)
+	if reason == C.MPV_END_FILE_REASON_ERROR {
+		message := C.GoString(C.mpv_error_string(C.supersonic_end_file_error(data)))
+		if message == "" {
+			message = "unknown error"
+		}
+		return errors.New(message)
+	}
+	if reason == C.MPV_END_FILE_REASON_EOF && isPrematureEOF(status) {
+		return fmt.Errorf("playback ended at %.2fs before the expected duration %.2fs", status.TimePos, status.Duration)
+	}
+	return nil
+}
+
+func isPrematureEOF(status player.Status) bool {
+	return status.Duration > 0 && status.TimePos >= 0 &&
+		status.Duration-status.TimePos > prematureEOFToleranceSeconds
+}

--- a/backend/player/mpv/endfile_test.go
+++ b/backend/player/mpv/endfile_test.go
@@ -1,0 +1,44 @@
+package mpv
+
+import (
+	"testing"
+
+	"github.com/supersonic-app/supersonic/backend/player"
+)
+
+func TestIsPrematureEOF(t *testing.T) {
+	tests := []struct {
+		name   string
+		status player.Status
+		want   bool
+	}{
+		{
+			name:   "network stream ended early",
+			status: player.Status{TimePos: 26.38, Duration: 274.11},
+			want:   true,
+		},
+		{
+			name:   "normal end within tolerance",
+			status: player.Status{TimePos: 299, Duration: 300},
+			want:   false,
+		},
+		{
+			name:   "unknown duration",
+			status: player.Status{TimePos: 26.38},
+			want:   false,
+		},
+		{
+			name:   "invalid negative position",
+			status: player.Status{TimePos: -1, Duration: 300},
+			want:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isPrematureEOF(tt.status); got != tt.want {
+				t.Fatalf("isPrematureEOF(%+v) = %v, want %v", tt.status, got, tt.want)
+			}
+		})
+	}
+}

--- a/backend/player/mpv/player.go
+++ b/backend/player/mpv/player.go
@@ -558,6 +558,10 @@ func (p *Player) eventHandler(ctx context.Context) {
 				}
 				p.InvokeOnTrackChange()
 				p.fileLoadedSig.Signal()
+			case mpv.EVENT_END_FILE:
+				if err := playbackErrorFromEndFileEvent(e.Data, p.GetStatus()); err != nil {
+					p.InvokeOnPlaybackError(err)
+				}
 			case mpv.EVENT_IDLE:
 				p.status.Duration = 0
 				p.status.TimePos = 0

--- a/backend/player/player.go
+++ b/backend/player/player.go
@@ -39,6 +39,11 @@ type BasePlayer interface {
 	OnTrackChange(func())
 }
 
+// PlaybackErrorPlayer optionally reports unexpected playback failures.
+type PlaybackErrorPlayer interface {
+	OnPlaybackError(func(error))
+}
+
 type ReplayGainPlayer interface {
 	SetReplayGainOptions(ReplayGainOptions) error
 }
@@ -88,11 +93,12 @@ func (r ReplayGainMode) String() string {
 }
 
 type BasePlayerCallbackImpl struct {
-	onPaused      func()
-	onStopped     func()
-	onPlaying     func()
-	onSeek        func()
-	onTrackChange func()
+	onPaused        func()
+	onStopped       func()
+	onPlaying       func()
+	onSeek          func()
+	onTrackChange   func()
+	onPlaybackError func(error)
 }
 
 // Sets a callback which is invoked when the player transitions to the Paused state.
@@ -122,6 +128,11 @@ func (p *BasePlayerCallbackImpl) OnTrackChange(cb func()) {
 	p.onTrackChange = cb
 }
 
+// Registers a callback which is invoked when playback fails unexpectedly.
+func (p *BasePlayerCallbackImpl) OnPlaybackError(cb func(error)) {
+	p.onPlaybackError = cb
+}
+
 func (p *BasePlayerCallbackImpl) InvokeOnPaused() {
 	if p.onPaused != nil {
 		p.onPaused()
@@ -149,5 +160,11 @@ func (p *BasePlayerCallbackImpl) InvokeOnSeek() {
 func (p *BasePlayerCallbackImpl) InvokeOnTrackChange() {
 	if p.onTrackChange != nil {
 		p.onTrackChange()
+	}
+}
+
+func (p *BasePlayerCallbackImpl) InvokeOnPlaybackError(err error) {
+	if p.onPlaybackError != nil {
+		p.onPlaybackError(err)
 	}
 }


### PR DESCRIPTION
## Description

Preserve the current track and playback position when an MPV stream is interrupted by a network error.

Previously, MPV transitioning to `Stopped` cleared the current queue index. Pressing Play then restarted the first queue item from `0:00`.

## Changes

- Detect MPV `END_FILE` errors and premature EOF events.
- Add an optional player error callback.
- Preserve the current queue index and last observed position after an error.
- Resume the same track from that position when Play is pressed.
- Keep explicit Stop and normal end-of-track behavior unchanged.
- Report the interrupted state as paused.

## Testing

- Added tests for error recovery, premature EOF, backward seeking, explicit Stop, queue preservation, and paused-state reporting.
- `go test ./...`
- `go test -race ./backend/player/mpv ./backend`
- Manually verified by interrupting a live TCP stream and restoring the connection.