### PR TITLE
fix: song radio passes track ID to wrong API endpoint

### DIFF
--- a/backend/mediaprovider/subsonic/subsonicmediaprovider.go
+++ b/backend/mediaprovider/subsonic/subsonicmediaprovider.go
@@ -797,6 +797,12 @@ func (s *subsonicMediaProvider) GetSongRadio(trackID string, count int) ([]*medi
 		ch <- result{tr, err}
 	}()
 
+	// The go-subsonic client has no context support, so we can't cancel the
+	// in-flight request directly. The goroutine will exit when the underlying
+	// http.Client timeout (RequestTimeoutSeconds) fires.
+	timer := time.NewTimer(10 * time.Second)
+	defer timer.Stop()
+
 	var tr []*subsonic.Child
 	select {
 	case res := <-ch:
@@ -805,7 +811,7 @@ func (s *subsonicMediaProvider) GetSongRadio(trackID string, count int) ([]*medi
 		} else {
 			tr = res.tracks
 		}
-	case <-time.After(10 * time.Second):
+	case <-timer.C:
 		log.Printf("GetSongRadio: getSimilarSongs timed out, using fallback")
 	}
 

--- a/backend/mediaprovider/subsonic/subsonicmediaprovider.go
+++ b/backend/mediaprovider/subsonic/subsonicmediaprovider.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"image"
 	"io"
+	"log"
 	"math"
 	"net/url"
 	"slices"
@@ -786,16 +787,34 @@ func fillPlaylist(pl *subsonic.Playlist, playlist *mediaprovider.Playlist) {
 }
 
 func (s *subsonicMediaProvider) GetSongRadio(trackID string, count int) ([]*mediaprovider.Track, error) {
-	tr, err := s.client.GetSimilarSongs(trackID, map[string]string{"count": strconv.Itoa(count)})
+	type result struct {
+		tracks []*subsonic.Child
+		err    error
+	}
+	ch := make(chan result, 1)
+	go func() {
+		tr, err := s.client.GetSimilarSongs(trackID, map[string]string{"count": strconv.Itoa(count)})
+		ch <- result{tr, err}
+	}()
+
+	var tr []*subsonic.Child
+	select {
+	case res := <-ch:
+		if res.err != nil {
+			log.Printf("GetSongRadio: getSimilarSongs failed (%v), using fallback", res.err)
+		} else {
+			tr = res.tracks
+		}
+	case <-time.After(10 * time.Second):
+		log.Printf("GetSongRadio: getSimilarSongs timed out, using fallback")
+	}
+
+	if len(tr) > 0 {
+		return sharedutil.MapSlice(tr, toTrack), nil
+	}
+	track, err := s.GetTrack(trackID)
 	if err != nil {
 		return nil, err
 	}
-	if len(tr) == 0 {
-		track, err := s.GetTrack(trackID)
-		if err != nil {
-			return nil, err
-		}
-		return helpers.GetSimilarSongsFallback(s, track, count), nil
-	}
-	return sharedutil.MapSlice(tr, toTrack), nil
+	return helpers.GetSimilarSongsFallback(s, track, count), nil
 }

--- a/backend/playbackmanager.go
+++ b/backend/playbackmanager.go
@@ -582,6 +582,12 @@ func (p *PlaybackManager) PlaySimilarSongs(id string) error {
 	})
 }
 
+func (p *PlaybackManager) PlaySongRadio(trackID string) error {
+	return p.fetchAndPlayTracks(func() ([]*mediaprovider.Track, error) {
+		return p.engine.sm.Server.GetSongRadio(trackID, p.appCfg.EnqueueBatchSize)
+	})
+}
+
 func (p *PlaybackManager) PlayRandomAlbums(genreName string) error {
 	mp := p.engine.sm.GetServer()
 	if mp == nil {

--- a/ui/browsing/nowplayingpage.go
+++ b/ui/browsing/nowplayingpage.go
@@ -174,7 +174,7 @@ func NewNowPlayingPage(
 	}
 	a.relatedList.OnPlaySongRadio = func(track *mediaprovider.Track) {
 		go func() {
-			if err := a.pm.PlaySimilarSongs(track.ID); err != nil {
+			if err := a.pm.PlaySongRadio(track.ID); err != nil {
 				fyne.Do(func() {
 					a.contr.ToastProvider.ShowErrorToast(lang.L("Unable to play song radio"))
 				})

--- a/ui/controller/connectactions.go
+++ b/ui/controller/connectactions.go
@@ -223,7 +223,7 @@ func (c *Controller) ConnectPlayQueuelistActions(list *widgets.PlayQueueList) {
 	list.OnSetFavorite = c.SetTrackFavorites
 	list.OnPlaySongRadio = func(track *mediaprovider.Track) {
 		go func() {
-			if err := c.App.PlaybackManager.PlaySimilarSongs(track.ID); err != nil {
+			if err := c.App.PlaybackManager.PlaySongRadio(track.ID); err != nil {
 				fyne.Do(func() {
 					c.ToastProvider.ShowErrorToast(lang.L("Unable to play song radio"))
 				})


### PR DESCRIPTION
When triggering Play Song Radio from the play queue or now playing page, the track ID was passed to GetSimilarTracks, which calls getSimilarSongs2 and expects an artist ID. This causes a server error on every attempt.

Fix by routing through GetSongRadio (getSimilarSongs), which accepts a track ID.

Also adds a 10s hard timeout and falls back to GetSimilarSongsFallback if the server errors or stalls, so the feature degrades gracefully instead of showing an error toast.