### PR TITLE
Display only the latest search results

### DIFF
--- a/ui/dialogs/searchdialog.go
+++ b/ui/dialogs/searchdialog.go
@@ -175,9 +175,9 @@ func (sd *SearchDialog) onSearched(query string) {
 		} else {
 			results = res
 		}
-		if(sd.resultsGeneration < generation) {
+		if sd.resultsGeneration < generation {
 			fyne.Do(func() {
-				if(sd.pendingResultsGeneration == generation) {
+				if sd.pendingResultsGeneration == generation {
 					sd.loadingDots.Stop()
 				}
 				sd.setResults(results)

--- a/ui/dialogs/searchdialog.go
+++ b/ui/dialogs/searchdialog.go
@@ -37,6 +37,8 @@ type SearchDialog struct {
 
 	imgSource     util.ImageFetcher
 	resultsMutex  sync.RWMutex
+	resultsGeneration int
+	pendingResultsGeneration int
 	searchResults []*mediaprovider.SearchResult
 	selectedIndex int
 
@@ -164,6 +166,8 @@ func (sd *SearchDialog) setResults(results []*mediaprovider.SearchResult) {
 func (sd *SearchDialog) onSearched(query string) {
 	sd.loadingDots.Start()
 	var results []*mediaprovider.SearchResult
+	sd.pendingResultsGeneration += 1
+	var generation = sd.pendingResultsGeneration
 	go func() {
 		res := sd.OnSearched(query)
 		if len(res) == 0 {
@@ -171,10 +175,15 @@ func (sd *SearchDialog) onSearched(query string) {
 		} else {
 			results = res
 		}
-		fyne.Do(func() {
-			sd.loadingDots.Stop()
-			sd.setResults(results)
-		})
+		if(sd.resultsGeneration < generation) {
+			fyne.Do(func() {
+				if(sd.pendingResultsGeneration == generation) {
+					sd.loadingDots.Stop()
+				}
+				sd.setResults(results)
+			})
+			sd.resultsGeneration = generation
+		}
 	}()
 }
 

--- a/ui/dialogs/searchdialog.go
+++ b/ui/dialogs/searchdialog.go
@@ -35,12 +35,12 @@ type SearchDialog struct {
 	OnShowContextMenu func(itemIdx int, pos fyne.Position)
 	OnSearched        func(string) []*mediaprovider.SearchResult
 
-	imgSource     util.ImageFetcher
-	resultsMutex  sync.RWMutex
-	resultsGeneration int
+	imgSource                util.ImageFetcher
+	resultsMutex             sync.RWMutex
+	resultsGeneration        int
 	pendingResultsGeneration int
-	searchResults []*mediaprovider.SearchResult
-	selectedIndex int
+	searchResults            []*mediaprovider.SearchResult
+	selectedIndex            int
 
 	searchEntry *searchEntry
 	loadingDots *widgets.LoadingDots


### PR DESCRIPTION
A generation counter is added to the search dialog, which assigns each in-flight search request a number; as the requests complete, they only display their results if their information is newer than what's currently displayed.

This fix is only relevant if the sd.OnSearched callback takes more than 200ms to complete, because of the debouncer in `searchentry.go`.

From CONTRIBUTING.md:
>  Before opening a pull request, please ensure the following things:
>
>    You have discussed your proposed changes with the project maintainer(s)

I have not done this! but I hope the PR is an alright place to discuss.  
This PR fixes a bug i've been experiencing using supersonic with my navidrome server.
Sometimes the very first character typed into "Search Everywhere" (e.g. "w") will be a really slow search, and complete *after* the full search I'm typing (e.g. "wannabe", which only has 3 hits). When the bug happens, the results I'm interested in (wannabe) flash on screen for a moment, before being replaced by the search results for "w".