### PR TITLE
feat(player): add truthful signal-path state

### DIFF
--- a/backend/playbackengine.go
+++ b/backend/playbackengine.go
@@ -973,14 +973,14 @@ func (p *playbackEngine) nextPlayingIndex() int {
 
 func (p *playbackEngine) setTrack(idx int, next bool, startTime float64) error {
 	var item mediaprovider.MediaItem
-	var url string
+	var source player.PlaybackSource
 	if idx >= 0 {
 		item = p.getPlayQueueItemAt(idx)
-		url = p.getMediaURLForIdx(idx)
+		source = p.getPlaybackSourceForIdx(idx)
 	}
 	track, isTrack := item.(*mediaprovider.Track)
 	if p.audiocache != nil && isTrack {
-		p.audiocache.CacheFile(item.Metadata().ID, p.getMediaURLForIdx(idx))
+		p.audiocache.CacheFile(item.Metadata().ID, source.URL)
 	}
 
 	if urlP, ok := p.player.(player.URLPlayer); ok {
@@ -989,7 +989,12 @@ func (p *playbackEngine) setTrack(idx int, next bool, startTime float64) error {
 			meta = item.Metadata()
 			if isTrack && p.audiocache != nil {
 				if filepath := p.audiocache.PathForCachedFile(track.ID); filepath != "" {
-					url = filepath
+					source.URL = filepath
+					source.Receipt.CompleteCache = true
+					source.Receipt.Evidence = append(source.Receipt.Evidence, player.EvidenceItem{
+						Kind:  "playback_source",
+						Value: "complete_cache",
+					})
 				}
 			}
 			if mpvP, ok := p.player.(*mpv.Player); ok && !isTrack {
@@ -1007,14 +1012,14 @@ func (p *playbackEngine) setTrack(idx int, next bool, startTime float64) error {
 			} else if ok {
 				mpvP.UnobserveIcyRadioTitle()
 			}
-			if url == "" {
+			if source.URL == "" {
 				return errors.New("no stream URL")
 			}
 		}
 		if next {
-			return urlP.SetNextFile(url, meta)
+			return urlP.SetNextFile(source, meta)
 		}
-		return urlP.PlayFile(url, meta, startTime)
+		return urlP.PlayFile(source, meta, startTime)
 	} else if trP, ok := p.player.(player.TrackPlayer); ok {
 		var track *mediaprovider.Track
 		if idx >= 0 {
@@ -1032,21 +1037,51 @@ func (p *playbackEngine) setTrack(idx int, next bool, startTime float64) error {
 }
 
 func (p *playbackEngine) getMediaURLForIdx(idx int) string {
-	var url string
+	return p.getPlaybackSourceForIdx(idx).URL
+}
+
+func (p *playbackEngine) getPlaybackSourceForIdx(idx int) player.PlaybackSource {
 	item := p.getPlayQueueItemAt(idx)
 	if tr, ok := item.(*mediaprovider.Track); ok {
-		var ts *mediaprovider.TranscodeSettings
-		if p.transcodeCfg.RequestTranscode {
-			ts = &mediaprovider.TranscodeSettings{
-				Codec:       p.transcodeCfg.Codec,
-				BitRateKBPS: p.transcodeCfg.MaxBitRateKBPS,
-			}
+		transcode, forceRaw, policy := streamRequestForConfig(*p.transcodeCfg)
+		url, _ := p.sm.Server.GetStreamURL(tr.ID, transcode, forceRaw)
+		return player.PlaybackSource{
+			URL: url,
+			Descriptor: player.SourceDescriptor{
+				ServerID:        p.sm.ServerID.String(),
+				TrackID:         tr.ID,
+				LibraryCodec:    tr.ContentType,
+				LibrarySuffix:   tr.Extension,
+				LibrarySize:     tr.Size,
+				LibraryRate:     tr.SampleRate,
+				LibraryBits:     tr.BitDepth,
+				LibraryChannels: tr.Channels,
+			},
+			Receipt: player.NewSourceReceipt(policy),
 		}
-		url, _ = p.sm.Server.GetStreamURL(tr.ID, ts, p.transcodeCfg.ForceRawFile)
-	} else {
-		url = item.(*mediaprovider.RadioStation).StreamURL
 	}
-	return url
+
+	radio := item.(*mediaprovider.RadioStation)
+	return player.PlaybackSource{
+		URL: radio.StreamURL,
+		Descriptor: player.SourceDescriptor{
+			TrackID: radio.ID,
+		},
+		Receipt: player.NewSourceReceipt(player.DeliveryExternalStream),
+	}
+}
+
+func streamRequestForConfig(config TranscodingConfig) (*mediaprovider.TranscodeSettings, bool, player.DeliveryPolicy) {
+	if config.RequestTranscode {
+		return &mediaprovider.TranscodeSettings{
+			Codec:       config.Codec,
+			BitRateKBPS: config.MaxBitRateKBPS,
+		}, false, player.DeliveryTranscodeRequested
+	}
+	if config.ForceRawFile {
+		return nil, true, player.DeliveryRawRequested
+	}
+	return nil, false, player.DeliveryServerDefault
 }
 
 func (p *playbackEngine) setNextTrack(idx int) error {

--- a/backend/playbackengine_source_test.go
+++ b/backend/playbackengine_source_test.go
@@ -1,0 +1,61 @@
+package backend
+
+import (
+	"testing"
+
+	"github.com/supersonic-app/supersonic/backend/player"
+)
+
+func TestStreamRequestForConfig(t *testing.T) {
+	tests := []struct {
+		name         string
+		config       TranscodingConfig
+		wantPolicy   player.DeliveryPolicy
+		wantForceRaw bool
+		wantCodec    string
+		wantBitrate  int
+	}{
+		{
+			name:       "server default",
+			wantPolicy: player.DeliveryServerDefault,
+		},
+		{
+			name: "raw",
+			config: TranscodingConfig{
+				ForceRawFile: true,
+			},
+			wantPolicy:   player.DeliveryRawRequested,
+			wantForceRaw: true,
+		},
+		{
+			name: "explicit transcode takes precedence",
+			config: TranscodingConfig{
+				ForceRawFile:     true,
+				RequestTranscode: true,
+				Codec:            "opus",
+				MaxBitRateKBPS:   320,
+			},
+			wantPolicy:  player.DeliveryTranscodeRequested,
+			wantCodec:   "opus",
+			wantBitrate: 320,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			transcode, forceRaw, policy := streamRequestForConfig(test.config)
+			if policy != test.wantPolicy || forceRaw != test.wantForceRaw {
+				t.Fatalf("policy/forceRaw = %q/%t, want %q/%t", policy, forceRaw, test.wantPolicy, test.wantForceRaw)
+			}
+			if test.wantCodec == "" {
+				if transcode != nil {
+					t.Fatalf("transcode = %#v, want nil", transcode)
+				}
+				return
+			}
+			if transcode == nil || transcode.Codec != test.wantCodec || transcode.BitRateKBPS != test.wantBitrate {
+				t.Fatalf("transcode = %#v, want %s at %d kbps", transcode, test.wantCodec, test.wantBitrate)
+			}
+		})
+	}
+}

--- a/backend/playbackmanager.go
+++ b/backend/playbackmanager.go
@@ -317,6 +317,35 @@ func (p *PlaybackManager) CurrentPlayer() player.BasePlayer {
 	return p.engine.CurrentPlayer()
 }
 
+// SignalPathSnapshot returns the current backend's immutable, redacted view of
+// the active playback path. Unknown backends fail closed instead of inheriting
+// claims from the previously active player.
+func (p *PlaybackManager) SignalPathSnapshot() player.PlaybackSnapshot {
+	if provider, ok := p.engine.CurrentPlayer().(player.SignalPathProvider); ok {
+		return provider.SignalPathSnapshot()
+	}
+	return player.ReduceSignalPath(player.SignalPathObservation{
+		Requested: player.ModeNormal,
+		Fallback: &player.FallbackReason{
+			Code:   player.FallbackEffectiveModeUnknown,
+			Detail: "the active player does not report signal-path state",
+		},
+	})
+}
+
+func (p *PlaybackManager) PlaybackCapabilities() player.PlaybackCapabilities {
+	if provider, ok := p.engine.CurrentPlayer().(player.CapabilityProvider); ok {
+		return provider.PlaybackCapabilities()
+	}
+	return player.PlaybackCapabilities{
+		EngineID: "unknown",
+		Normal: player.ModeCapability{
+			Status: player.CapabilityUnverified,
+			Reason: "the active player does not report capabilities",
+		},
+	}
+}
+
 func (p *PlaybackManager) OnPlayerChange(cb func()) {
 	p.onPlayerChange = append(p.onPlayerChange, cb)
 }

--- a/backend/player/capabilities.go
+++ b/backend/player/capabilities.go
@@ -1,0 +1,48 @@
+package player
+
+type CapabilityStatus string
+
+const (
+	CapabilityUnsupported CapabilityStatus = "unsupported"
+	CapabilityUnverified  CapabilityStatus = "unverified"
+	CapabilitySupported   CapabilityStatus = "supported"
+)
+
+type ModeCapability struct {
+	Status CapabilityStatus
+	Reason string
+}
+
+// PlaybackCapabilities is intentionally about provable product modes rather
+// than a backend's raw option list.
+type PlaybackCapabilities struct {
+	EngineID           string
+	Normal             ModeCapability
+	ExclusiveProcessed ModeCapability
+	StrictPCM          ModeCapability
+	StrictDoP          ModeCapability
+	RemoteRenderer     ModeCapability
+}
+
+func (c PlaybackCapabilities) ForMode(mode RequestedMode) ModeCapability {
+	switch mode {
+	case ModeNormal:
+		return c.Normal
+	case ModeExclusiveProcessed:
+		return c.ExclusiveProcessed
+	case ModeStrict:
+		if c.StrictPCM.Status == CapabilitySupported || c.StrictDoP.Status == CapabilitySupported {
+			return ModeCapability{Status: CapabilitySupported}
+		}
+		if c.StrictPCM.Status == CapabilityUnverified || c.StrictDoP.Status == CapabilityUnverified {
+			return ModeCapability{Status: CapabilityUnverified, Reason: "strict output requires runtime verification"}
+		}
+		return ModeCapability{Status: CapabilityUnsupported, Reason: "strict output is unsupported"}
+	default:
+		return ModeCapability{Status: CapabilityUnsupported, Reason: "unknown requested mode"}
+	}
+}
+
+type CapabilityProvider interface {
+	PlaybackCapabilities() PlaybackCapabilities
+}

--- a/backend/player/capabilities_test.go
+++ b/backend/player/capabilities_test.go
@@ -1,0 +1,29 @@
+package player
+
+import "testing"
+
+func TestPlaybackCapabilitiesCombinesStrictTransports(t *testing.T) {
+	tests := []struct {
+		name string
+		pcm  CapabilityStatus
+		dop  CapabilityStatus
+		want CapabilityStatus
+	}{
+		{"supported PCM", CapabilitySupported, CapabilityUnsupported, CapabilitySupported},
+		{"supported DoP", CapabilityUnsupported, CapabilitySupported, CapabilitySupported},
+		{"unverified PCM", CapabilityUnverified, CapabilityUnsupported, CapabilityUnverified},
+		{"unsupported", CapabilityUnsupported, CapabilityUnsupported, CapabilityUnsupported},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			capabilities := PlaybackCapabilities{
+				StrictPCM: ModeCapability{Status: test.pcm},
+				StrictDoP: ModeCapability{Status: test.dop},
+			}
+			if got := capabilities.ForMode(ModeStrict).Status; got != test.want {
+				t.Fatalf("strict status = %q, want %q", got, test.want)
+			}
+		})
+	}
+}

--- a/backend/player/dlna/dlnaplayer.go
+++ b/backend/player/dlna/dlnaplayer.go
@@ -58,6 +58,9 @@ type DLNAPlayer struct {
 	metaLock      sync.Mutex
 	curTrackMeta  mediaprovider.MediaItemMetadata
 	nextTrackMeta mediaprovider.MediaItemMetadata
+	curSource     player.PlaybackSource
+	nextSource    player.PlaybackSource
+	signalPath    *player.SignalPathState
 
 	// if true, report playback time 00:00
 	// pending time sync with player after beginning playback
@@ -95,6 +98,10 @@ type DLNAPlayer struct {
 	resetChan   chan (time.Duration)
 }
 
+var _ player.URLPlayer = (*DLNAPlayer)(nil)
+var _ player.SignalPathProvider = (*DLNAPlayer)(nil)
+var _ player.CapabilityProvider = (*DLNAPlayer)(nil)
+
 func NewDLNAPlayer(device *device.MediaRenderer, coverArtPathFn func(coverArtID string) (string, error)) (*DLNAPlayer, error) {
 	retry := retryablehttp.NewClient()
 	retry.RetryMax = 3
@@ -120,11 +127,17 @@ func NewDLNAPlayer(device *device.MediaRenderer, coverArtPathFn func(coverArtID 
 		return nil, fmt.Errorf("failed to connect to %s", device.FriendlyName)
 	}
 
+	observation := player.SignalPathObservation{
+		Requested:      player.ModeNormal,
+		RemoteRenderer: true,
+		Receipt:        player.NewSourceReceipt(player.DeliveryExternalStream),
+	}
 	return &DLNAPlayer{
 		avTransport:    avt,
 		renderControl:  rc,
 		resetChan:      make(chan time.Duration),
 		coverArtPathFn: coverArtPathFn,
+		signalPath:     player.NewSignalPathState(player.ReduceSignalPath(observation)),
 	}, nil
 }
 
@@ -183,7 +196,7 @@ func (d *DLNAPlayer) GetVolume() int {
 	return vol
 }
 
-func (d *DLNAPlayer) PlayFile(urlstr string, meta mediaprovider.MediaItemMetadata, startTime float64) error {
+func (d *DLNAPlayer) PlayFile(source player.PlaybackSource, meta mediaprovider.MediaItemMetadata, startTime float64) error {
 	if d.destroyed {
 		return nil
 	}
@@ -192,14 +205,17 @@ func (d *DLNAPlayer) PlayFile(urlstr string, meta mediaprovider.MediaItemMetadat
 
 	d.metaLock.Lock()
 	d.curTrackMeta = meta
+	d.curSource = source.Clone()
+	d.nextSource = player.PlaybackSource{}
 	d.metaLock.Unlock()
-	key := d.addURLToProxy(urlstr)
+	key := d.addURLToProxy(source.URL)
 
 	media := d.buildMediaItem(d.urlForItem(key), meta)
 
 	if err := d.playAVTransportMedia(&media); err != nil {
 		return err
 	}
+	d.publishSignalPath(source)
 	d.pendingPlayStart = true
 	if startTime > 0 {
 		// TODO: do something better than this!!
@@ -247,7 +263,7 @@ func (d *DLNAPlayer) playAVTransportMedia(media *avtransport.MediaItem) error {
 	return nil
 }
 
-func (d *DLNAPlayer) SetNextFile(url string, meta mediaprovider.MediaItemMetadata) error {
+func (d *DLNAPlayer) SetNextFile(source player.PlaybackSource, meta mediaprovider.MediaItemMetadata) error {
 	if d.destroyed {
 		return nil
 	}
@@ -255,11 +271,12 @@ func (d *DLNAPlayer) SetNextFile(url string, meta mediaprovider.MediaItemMetadat
 	var media *avtransport.MediaItem
 	d.metaLock.Lock()
 	d.nextTrackMeta = meta
+	d.nextSource = source.Clone()
 	d.metaLock.Unlock()
-	if url != "" {
+	if source.URL != "" {
 		d.ensureSetupProxy()
 
-		key := d.addURLToProxy(url)
+		key := d.addURLToProxy(source.URL)
 		item := d.buildMediaItem(d.urlForItem(key), meta)
 		media = &item
 	} else {
@@ -547,6 +564,9 @@ func (d *DLNAPlayer) handleOnTrackChange() {
 	}
 	d.curTrackMeta = d.nextTrackMeta
 	d.nextTrackMeta = mediaprovider.MediaItemMetadata{}
+	d.curSource = d.nextSource
+	d.nextSource = player.PlaybackSource{}
+	currentSource := d.curSource.Clone()
 	nextTrackChange := d.curTrackMeta.Duration
 	d.metaLock.Unlock()
 
@@ -555,6 +575,7 @@ func (d *DLNAPlayer) handleOnTrackChange() {
 		d.stopwatch.Reset()
 		d.InvokeOnStopped()
 	} else {
+		d.publishSignalPath(currentSource)
 		d.metaLock.Lock()
 		if d.failedToSetNext {
 			d.failedToSetNext = false
@@ -579,6 +600,51 @@ func (d *DLNAPlayer) handleOnTrackChange() {
 			}
 		}()
 	}
+}
+
+func (d *DLNAPlayer) PlaybackCapabilities() player.PlaybackCapabilities {
+	return player.PlaybackCapabilities{
+		EngineID: "dlna",
+		Normal: player.ModeCapability{
+			Status: player.CapabilitySupported,
+		},
+		ExclusiveProcessed: player.ModeCapability{
+			Status: player.CapabilityUnsupported,
+			Reason: "the remote renderer owns its output mode",
+		},
+		StrictPCM: player.ModeCapability{
+			Status: player.CapabilityUnsupported,
+			Reason: "the remote renderer's DAC path cannot be verified locally",
+		},
+		StrictDoP: player.ModeCapability{
+			Status: player.CapabilityUnsupported,
+			Reason: "the remote renderer's DSD transport cannot be verified locally",
+		},
+		RemoteRenderer: player.ModeCapability{
+			Status: player.CapabilitySupported,
+		},
+	}
+}
+
+func (d *DLNAPlayer) SignalPathSnapshot() player.PlaybackSnapshot {
+	return d.signalPath.Snapshot()
+}
+
+func (d *DLNAPlayer) OnSignalPathChange(callback func(player.PlaybackSnapshot)) {
+	d.signalPath.OnChange(callback)
+}
+
+func (d *DLNAPlayer) publishSignalPath(source player.PlaybackSource) {
+	snapshot := player.ReduceSignalPath(player.SignalPathObservation{
+		Requested:      player.ModeNormal,
+		Source:         source.Descriptor,
+		Receipt:        source.Receipt,
+		RemoteRenderer: true,
+		Generation:     d.signalPath.Snapshot().Generation + 1,
+	})
+	d.signalPath.Update(func(current *player.PlaybackSnapshot) {
+		*current = snapshot
+	})
 }
 
 func (d *DLNAPlayer) urlForItem(key string) string {

--- a/backend/player/dlna/signalpath_test.go
+++ b/backend/player/dlna/signalpath_test.go
@@ -1,0 +1,30 @@
+package dlna
+
+import (
+	"testing"
+
+	"github.com/supersonic-app/supersonic/backend/player"
+)
+
+func TestDLNASnapshotIsAlwaysRemoteRenderer(t *testing.T) {
+	initial := player.ReduceSignalPath(player.SignalPathObservation{
+		Requested:      player.ModeNormal,
+		RemoteRenderer: true,
+	})
+	d := &DLNAPlayer{signalPath: player.NewSignalPathState(initial)}
+	d.publishSignalPath(player.PlaybackSource{
+		Descriptor: player.SourceDescriptor{TrackID: "track"},
+		Receipt:    player.NewSourceReceipt(player.DeliveryRawRequested),
+	})
+
+	snapshot := d.SignalPathSnapshot()
+	if snapshot.Effective != player.EffectiveRemoteRenderer {
+		t.Fatalf("effective mode = %q, want remote_renderer", snapshot.Effective)
+	}
+	if snapshot.Source.TrackID != "track" || snapshot.Receipt.DeliveryPolicy != player.DeliveryRawRequested {
+		t.Fatalf("source evidence was not retained: %#v", snapshot)
+	}
+	if snapshot.IsBitPerfect() {
+		t.Fatal("DLNA snapshot claimed the remote DAC path is bit-perfect")
+	}
+}

--- a/backend/player/jukebox/jukeboxplayer.go
+++ b/backend/player/jukebox/jukeboxplayer.go
@@ -1,6 +1,7 @@
 package jukebox
 
 import (
+	"sync"
 	"time"
 
 	"github.com/supersonic-app/supersonic/backend/mediaprovider"
@@ -27,7 +28,14 @@ type JukeboxPlayer struct {
 	curTrackDuration   float64
 	startTrackTime     float64
 	startedAtUnixMilli int64
+
+	signalPathOnce sync.Once
+	signalPath     *player.SignalPathState
 }
+
+var _ player.TrackPlayer = (*JukeboxPlayer)(nil)
+var _ player.SignalPathProvider = (*JukeboxPlayer)(nil)
+var _ player.CapabilityProvider = (*JukeboxPlayer)(nil)
 
 func (j *JukeboxPlayer) SetVolume(vol int) error {
 	if err := j.provider.JukeboxSetVolume(vol); err != nil {
@@ -91,6 +99,7 @@ func (j *JukeboxPlayer) PlayTrack(track *mediaprovider.Track, _ float64) error {
 	j.curTrack = 0
 	j.queueLength = 1
 	j.curTrackDuration = track.Duration.Seconds()
+	j.publishSignalPath(track)
 
 	return nil
 }
@@ -139,6 +148,72 @@ func (j *JukeboxPlayer) GetStatus() player.Status {
 }
 
 func (j *JukeboxPlayer) Destroy() {}
+
+func (j *JukeboxPlayer) PlaybackCapabilities() player.PlaybackCapabilities {
+	return player.PlaybackCapabilities{
+		EngineID: "jukebox",
+		Normal: player.ModeCapability{
+			Status: player.CapabilitySupported,
+		},
+		ExclusiveProcessed: player.ModeCapability{
+			Status: player.CapabilityUnsupported,
+			Reason: "the server-controlled player owns its output mode",
+		},
+		StrictPCM: player.ModeCapability{
+			Status: player.CapabilityUnsupported,
+			Reason: "the server-controlled DAC path cannot be verified locally",
+		},
+		StrictDoP: player.ModeCapability{
+			Status: player.CapabilityUnsupported,
+			Reason: "the server-controlled DSD path cannot be verified locally",
+		},
+		RemoteRenderer: player.ModeCapability{
+			Status: player.CapabilitySupported,
+		},
+	}
+}
+
+func (j *JukeboxPlayer) SignalPathSnapshot() player.PlaybackSnapshot {
+	return j.signalPathState().Snapshot()
+}
+
+func (j *JukeboxPlayer) OnSignalPathChange(callback func(player.PlaybackSnapshot)) {
+	j.signalPathState().OnChange(callback)
+}
+
+func (j *JukeboxPlayer) signalPathState() *player.SignalPathState {
+	j.signalPathOnce.Do(func() {
+		observation := player.SignalPathObservation{
+			Requested:      player.ModeNormal,
+			RemoteRenderer: true,
+			Receipt:        player.NewSourceReceipt(player.DeliveryRemoteControlled),
+		}
+		j.signalPath = player.NewSignalPathState(player.ReduceSignalPath(observation))
+	})
+	return j.signalPath
+}
+
+func (j *JukeboxPlayer) publishSignalPath(track *mediaprovider.Track) {
+	state := j.signalPathState()
+	snapshot := player.ReduceSignalPath(player.SignalPathObservation{
+		Requested: player.ModeNormal,
+		Source: player.SourceDescriptor{
+			TrackID:         track.ID,
+			LibraryCodec:    track.ContentType,
+			LibrarySuffix:   track.Extension,
+			LibrarySize:     track.Size,
+			LibraryRate:     track.SampleRate,
+			LibraryBits:     track.BitDepth,
+			LibraryChannels: track.Channels,
+		},
+		Receipt:        player.NewSourceReceipt(player.DeliveryRemoteControlled),
+		RemoteRenderer: true,
+		Generation:     state.Snapshot().Generation + 1,
+	})
+	state.Update(func(current *player.PlaybackSnapshot) {
+		*current = snapshot
+	})
+}
 
 func (j *JukeboxPlayer) startAndUpdateTime() error {
 	beforeStart := time.Now()

--- a/backend/player/jukebox/signalpath_test.go
+++ b/backend/player/jukebox/signalpath_test.go
@@ -1,0 +1,31 @@
+package jukebox
+
+import (
+	"testing"
+
+	"github.com/supersonic-app/supersonic/backend/mediaprovider"
+	"github.com/supersonic-app/supersonic/backend/player"
+)
+
+func TestJukeboxSnapshotIsAlwaysRemoteRenderer(t *testing.T) {
+	j := &JukeboxPlayer{}
+	j.publishSignalPath(&mediaprovider.Track{
+		ID:          "track",
+		ContentType: "audio/flac",
+		Extension:   "flac",
+		SampleRate:  96000,
+		BitDepth:    24,
+		Channels:    2,
+	})
+
+	snapshot := j.SignalPathSnapshot()
+	if snapshot.Effective != player.EffectiveRemoteRenderer {
+		t.Fatalf("effective mode = %q, want remote_renderer", snapshot.Effective)
+	}
+	if snapshot.Source.TrackID != "track" || snapshot.Receipt.DeliveryPolicy != player.DeliveryRemoteControlled {
+		t.Fatalf("source evidence was not retained: %#v", snapshot)
+	}
+	if snapshot.IsBitPerfect() {
+		t.Fatal("Jukebox snapshot claimed the remote DAC path is bit-perfect")
+	}
+}

--- a/backend/player/mode.go
+++ b/backend/player/mode.go
@@ -1,0 +1,95 @@
+package player
+
+// RequestedMode describes the playback policy selected by the user. It is an
+// intent, not proof that the output path actually satisfies that policy.
+type RequestedMode string
+
+const (
+	ModeNormal             RequestedMode = "normal"
+	ModeExclusiveProcessed RequestedMode = "exclusive_processed"
+	ModeStrict             RequestedMode = "strict_auto"
+)
+
+// EffectiveMode describes what the active signal path is known to be doing.
+// EffectiveUnverified is intentionally distinct from a fallback: the player
+// has not observed enough runtime facts to claim either success or failure.
+type EffectiveMode string
+
+const (
+	EffectiveUnverified         EffectiveMode = "unverified"
+	EffectiveSharedProcessed    EffectiveMode = "shared_processed"
+	EffectiveExclusiveProcessed EffectiveMode = "exclusive_processed"
+	EffectiveStrictPCM          EffectiveMode = "strict_pcm"
+	EffectiveStrictDoP          EffectiveMode = "strict_dop"
+	EffectiveNativeDSD          EffectiveMode = "native_dsd"
+	EffectiveConvertedDSD       EffectiveMode = "converted_dsd_pcm"
+	EffectiveStrictUnverified   EffectiveMode = "strict_unverified"
+	EffectiveFallback           EffectiveMode = "fallback_processed"
+	EffectiveUnsupported        EffectiveMode = "unsupported"
+	EffectiveRemoteRenderer     EffectiveMode = "remote_renderer"
+)
+
+// VerificationLevel records the strongest evidence available for the current
+// output generation. Levels are ordered by evidence strength.
+type VerificationLevel string
+
+const (
+	VerificationUnknown          VerificationLevel = "unknown"
+	VerificationConfigured       VerificationLevel = "configured"
+	VerificationNegotiated       VerificationLevel = "negotiated"
+	VerificationObserved         VerificationLevel = "observed"
+	VerificationHardwareVerified VerificationLevel = "hardware_verified"
+)
+
+func (v VerificationLevel) AtLeast(other VerificationLevel) bool {
+	return verificationRank(v) >= verificationRank(other)
+}
+
+func verificationRank(v VerificationLevel) int {
+	switch v {
+	case VerificationConfigured:
+		return 1
+	case VerificationNegotiated:
+		return 2
+	case VerificationObserved:
+		return 3
+	case VerificationHardwareVerified:
+		return 4
+	default:
+		return 0
+	}
+}
+
+type FallbackPolicy string
+
+const (
+	FallbackVisible FallbackPolicy = "allow_visible_fallback"
+	FallbackStop    FallbackPolicy = "stop_on_failure"
+)
+
+type FallbackReasonCode string
+
+const (
+	FallbackServerTranscoded           FallbackReasonCode = "server_transcoded"
+	FallbackSourceLossy                FallbackReasonCode = "source_lossy"
+	FallbackDeviceMissing              FallbackReasonCode = "device_missing"
+	FallbackExclusiveDenied            FallbackReasonCode = "exclusive_denied"
+	FallbackEffectiveModeUnknown       FallbackReasonCode = "effective_mode_unknown"
+	FallbackFormatUnsupported          FallbackReasonCode = "format_unsupported"
+	FallbackRateMismatch               FallbackReasonCode = "rate_mismatch"
+	FallbackBitDepthMismatch           FallbackReasonCode = "bit_depth_mismatch"
+	FallbackChannelMappingRequired     FallbackReasonCode = "channel_mapping_required"
+	FallbackResamplerActive            FallbackReasonCode = "resampler_active"
+	FallbackSoftwareGainActive         FallbackReasonCode = "software_gain_active"
+	FallbackFilterActive               FallbackReasonCode = "filter_active"
+	FallbackDoPCarrierUnsupported      FallbackReasonCode = "dop_carrier_unsupported"
+	FallbackRawDSDUnavailable          FallbackReasonCode = "raw_dsd_unavailable"
+	FallbackDeviceDisconnected         FallbackReasonCode = "device_disconnected"
+	FallbackUnderrunFillInjected       FallbackReasonCode = "underrun_fill_injected"
+	FallbackRemoteRendererUnverifiable FallbackReasonCode = "remote_renderer_unverifiable"
+)
+
+type FallbackReason struct {
+	Code   FallbackReasonCode
+	Detail string
+}

--- a/backend/player/mpv/player.go
+++ b/backend/player/mpv/player.go
@@ -50,6 +50,8 @@ type MediaInfo struct {
 }
 
 var _ player.URLPlayer = (*Player)(nil)
+var _ player.SignalPathProvider = (*Player)(nil)
+var _ player.CapabilityProvider = (*Player)(nil)
 
 // Player encapsulates the mpv instance and provides functions
 // to control it and to check its status.
@@ -72,6 +74,13 @@ type Player struct {
 	peaksEnabled   bool
 	pauseFade      bool
 
+	signalPathMu          sync.Mutex
+	signalPathObservation player.SignalPathObservation
+	signalPath            *player.SignalPathState
+	sourceMu              sync.Mutex
+	nextSource            player.PlaybackSource
+	haveNextSource        bool
+
 	icyTitleCb func(string)
 
 	fileLoadedLock sync.Mutex
@@ -90,9 +99,17 @@ func New() *Player {
 // Same as New, but sets the application name that mpv
 // reports to the system audio API.
 func NewWithClientName(c string) *Player {
+	observation := player.SignalPathObservation{
+		Requested: player.ModeNormal,
+		Output: player.OutputState{
+			Backend: "mpv",
+		},
+	}
 	p := &Player{
-		vol:        -1, // use 100 in Init
-		clientName: c,
+		vol:                   -1, // use 100 in Init
+		clientName:            c,
+		signalPathObservation: observation,
+		signalPath:            player.NewSignalPathState(player.ReduceSignalPath(observation)),
 	}
 	p.fileLoadedSig = sync.NewCond(&p.fileLoadedLock)
 	return p
@@ -148,14 +165,19 @@ func (p *Player) Init(maxCacheMB int) error {
 }
 
 // Plays the specified file, clearing the previous play queue, if any.
-func (p *Player) PlayFile(url string, _ mediaprovider.MediaItemMetadata, startTime float64) error {
+func (p *Player) PlayFile(source player.PlaybackSource, _ mediaprovider.MediaItemMetadata, startTime float64) error {
 	if !p.initialized {
 		return ErrUnitialized
 	}
-	err := p.mpv.Command([]string{"loadfile", url, "replace"})
+	p.sourceMu.Lock()
+	p.haveNextSource = false
+	p.nextSource = player.PlaybackSource{}
+	p.sourceMu.Unlock()
+	err := p.mpv.Command([]string{"loadfile", source.URL, "replace"})
 	if err != nil {
 		return err
 	}
+	p.setCurrentSource(source)
 	p.lenPlaylist = 1
 	if p.status.State == player.Paused {
 		err = p.Continue()
@@ -193,20 +215,28 @@ func (p *Player) Stop(_ bool) error {
 	return err
 }
 
-func (p *Player) SetNextFile(url string, _ mediaprovider.MediaItemMetadata) error {
+func (p *Player) SetNextFile(source player.PlaybackSource, _ mediaprovider.MediaItemMetadata) error {
 	if p.lenPlaylist > p.curPlaylistPos+1 {
 		if err := p.mpv.Command([]string{"playlist-remove", strconv.Itoa(int(p.curPlaylistPos) + 1)}); err != nil {
 			return err
 		}
 		p.lenPlaylist--
 	}
-	if url == "" {
+	p.sourceMu.Lock()
+	p.haveNextSource = false
+	p.nextSource = player.PlaybackSource{}
+	p.sourceMu.Unlock()
+	if source.URL == "" {
 		return nil
 	}
 
-	err := p.mpv.Command([]string{"loadfile", url, "append"})
+	err := p.mpv.Command([]string{"loadfile", source.URL, "append"})
 	if err == nil {
 		p.lenPlaylist++
+		p.sourceMu.Lock()
+		p.nextSource = source.Clone()
+		p.haveNextSource = true
+		p.sourceMu.Unlock()
 	}
 	return err
 }
@@ -236,10 +266,22 @@ func (p *Player) SetVolume(vol int) error {
 		err := p.mpv.SetProperty("volume", mpv.FORMAT_INT64, vol)
 		if err == nil {
 			p.vol = vol
+			p.setProcessingStage(player.ProcessingStage{
+				Kind:           player.ProcessingSoftwareVolume,
+				Active:         vol != 100,
+				ChangesSamples: true,
+				Reason:         "mpv software volume is not unity",
+			})
 		}
 		return err
 	}
 	p.vol = vol
+	p.setProcessingStage(player.ProcessingStage{
+		Kind:           player.ProcessingSoftwareVolume,
+		Active:         vol != 100,
+		ChangesSamples: true,
+		Reason:         "mpv software volume is not unity",
+	})
 	return nil
 }
 
@@ -272,6 +314,12 @@ func (p *Player) SetReplayGainOptions(options player.ReplayGainOptions) error {
 			return err
 		}
 	}
+	p.setProcessingStage(player.ProcessingStage{
+		Kind:           player.ProcessingReplayGain,
+		Active:         options.Mode != player.ReplayGainNone,
+		ChangesSamples: true,
+		Reason:         "ReplayGain is enabled",
+	})
 	return nil
 }
 
@@ -287,10 +335,25 @@ func (p *Player) SetAudioExclusive(tf bool) {
 		}
 		p.mpv.SetOptionString("audio-exclusive", val)
 	}
+	p.updateSignalPath(func(observation *player.SignalPathObservation) {
+		observation.Requested = player.ModeNormal
+		if tf {
+			observation.Requested = player.ModeExclusiveProcessed
+		}
+		observation.Output.ExclusiveKnown = false
+		observation.Negotiated = false
+		observation.RuntimeObserved = false
+	})
 }
 
 func (p *Player) SetPauseFade(pauseFade bool) {
 	p.pauseFade = pauseFade
+	p.setProcessingStage(player.ProcessingStage{
+		Kind:           player.ProcessingFade,
+		Active:         pauseFade,
+		ChangesSamples: true,
+		Reason:         "pause fade is enabled",
+	})
 }
 
 // Gets the current volume of the player.
@@ -411,12 +474,29 @@ func (p *Player) ListAudioDevices() ([]AudioDevice, error) {
 }
 
 func (p *Player) SetAudioDevice(deviceName string) error {
-	return p.mpv.SetPropertyString("audio-device", deviceName)
+	if err := p.mpv.SetPropertyString("audio-device", deviceName); err != nil {
+		return err
+	}
+	p.updateSignalPath(func(observation *player.SignalPathObservation) {
+		observation.Device.RequestedID = deviceName
+		observation.Device.IdentityKnown = false
+	})
+	return nil
 }
 
 func (p *Player) SetEqualizer(eq Equalizer) error {
 	p.equalizer = eq
-	return p.setAF()
+	if err := p.setAF(); err != nil {
+		return err
+	}
+	active := eq != nil && eq.IsEnabled() && (math.Abs(eq.Preamp()) > 0.01 || eq.Curve().String() != "")
+	p.setProcessingStage(player.ProcessingStage{
+		Kind:           player.ProcessingEqualizer,
+		Active:         active,
+		ChangesSamples: true,
+		Reason:         "equalizer or equalizer preamp is active",
+	})
+	return nil
 }
 
 func (p *Player) Equalizer() Equalizer {
@@ -444,6 +524,123 @@ func (p *Player) GetMediaInfo() (MediaInfo, error) {
 	}
 
 	return info, nil
+}
+
+func (p *Player) PlaybackCapabilities() player.PlaybackCapabilities {
+	return player.PlaybackCapabilities{
+		EngineID: "mpv",
+		Normal: player.ModeCapability{
+			Status: player.CapabilitySupported,
+		},
+		ExclusiveProcessed: player.ModeCapability{
+			Status: player.CapabilityUnverified,
+			Reason: "current libmpv does not expose effective exclusive state",
+		},
+		StrictPCM: player.ModeCapability{
+			Status: player.CapabilityUnverified,
+			Reason: "strict PCM requires effective output and conversion telemetry",
+		},
+		StrictDoP: player.ModeCapability{
+			Status: player.CapabilityUnsupported,
+			Reason: "mpv does not preserve raw DSD for DoP transport",
+		},
+		RemoteRenderer: player.ModeCapability{
+			Status: player.CapabilityUnsupported,
+		},
+	}
+}
+
+func (p *Player) SignalPathSnapshot() player.PlaybackSnapshot {
+	return p.signalPath.Snapshot()
+}
+
+func (p *Player) OnSignalPathChange(callback func(player.PlaybackSnapshot)) {
+	p.signalPath.OnChange(callback)
+}
+
+func (p *Player) updateSignalPath(update func(*player.SignalPathObservation)) {
+	p.signalPathMu.Lock()
+	update(&p.signalPathObservation)
+	snapshot := player.ReduceSignalPath(p.signalPathObservation)
+	p.signalPathMu.Unlock()
+	p.signalPath.Update(func(current *player.PlaybackSnapshot) {
+		*current = snapshot
+	})
+}
+
+func (p *Player) setCurrentSource(source player.PlaybackSource) {
+	p.updateSignalPath(func(observation *player.SignalPathObservation) {
+		observation.Source = source.Descriptor
+		observation.Receipt = source.Receipt.Clone()
+		observation.Decoder = player.DecoderState{}
+		observation.Output.FormatKnown = false
+		observation.Output.ProcessingKnown = false
+		observation.Negotiated = false
+		observation.RuntimeObserved = false
+		observation.HardwareVerified = false
+		observation.Fallback = nil
+		observation.Generation++
+	})
+}
+
+func (p *Player) promoteNextSource() {
+	p.sourceMu.Lock()
+	if !p.haveNextSource {
+		p.sourceMu.Unlock()
+		return
+	}
+	source := p.nextSource.Clone()
+	p.nextSource = player.PlaybackSource{}
+	p.haveNextSource = false
+	p.sourceMu.Unlock()
+	p.setCurrentSource(source)
+}
+
+func (p *Player) refreshDecoderState() {
+	info, err := p.GetMediaInfo()
+	if err != nil {
+		return
+	}
+	lossless := isLosslessCodec(info.Codec)
+	p.updateSignalPath(func(observation *player.SignalPathObservation) {
+		observation.Decoder = player.DecoderState{
+			Available: true,
+			Codec:     info.Codec,
+			Bitrate:   info.Bitrate,
+			Format: player.AudioFormat{
+				SampleFormat: info.Format,
+				SampleRate:   info.Samplerate,
+				Channels:     info.ChannelCount,
+			},
+			Lossless: lossless,
+		}
+		observation.Receipt.DeliveredCodec = info.Codec
+		observation.Receipt.DeliveredRate = info.Samplerate
+		observation.Receipt.DeliveredChannels = info.ChannelCount
+		observation.Receipt.DeliveredLossless = lossless
+		observation.Receipt.LosslessKnown = info.Codec != ""
+	})
+}
+
+func isLosslessCodec(codec string) bool {
+	switch strings.ToLower(codec) {
+	case "alac", "ape", "flac", "mlp", "tak", "truehd", "tta", "wavpack":
+		return true
+	default:
+		return strings.HasPrefix(strings.ToLower(codec), "pcm_")
+	}
+}
+
+func (p *Player) setProcessingStage(stage player.ProcessingStage) {
+	p.updateSignalPath(func(observation *player.SignalPathObservation) {
+		for i := range observation.Processing {
+			if observation.Processing[i].Kind == stage.Kind {
+				observation.Processing[i] = stage
+				return
+			}
+		}
+		observation.Processing = append(observation.Processing, stage)
+	})
 }
 
 func (p *Player) ObserveIcyRadioTitle(cb func(string)) {
@@ -489,7 +686,16 @@ func (p *Player) SetPeaksEnabled(enabled bool) error {
 		return nil
 	}
 	p.peaksEnabled = enabled
-	return p.setAF()
+	if err := p.setAF(); err != nil {
+		return err
+	}
+	p.setProcessingStage(player.ProcessingStage{
+		Kind:           player.ProcessingAnalyzer,
+		Active:         enabled,
+		ChangesSamples: false,
+		Reason:         "mpv astats peak analyzer is inserted in the audio filter graph",
+	})
+	return nil
 }
 
 func (p *Player) GetPeaks() (float64, float64, float64, float64) {
@@ -550,7 +756,12 @@ func (p *Player) eventHandler(ctx context.Context) {
 				p.seeking = false
 				p.InvokeOnSeek()
 			case mpv.EVENT_FILE_LOADED:
+				previousPlaylistPos := p.curPlaylistPos
 				p.curPlaylistPos, _ = p.getInt64Property("playlist-pos")
+				if p.curPlaylistPos != previousPlaylistPos {
+					p.promoteNextSource()
+				}
+				p.refreshDecoderState()
 				if p.status.State == player.Paused {
 					// seek while paused switches to a new file
 					// mpv does not fire seek event in this case

--- a/backend/player/mpv/signalpath_test.go
+++ b/backend/player/mpv/signalpath_test.go
@@ -1,0 +1,112 @@
+package mpv
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/supersonic-app/supersonic/backend/player"
+)
+
+func TestExclusiveRequestRemainsUnverifiedWithoutRuntimeEvidence(t *testing.T) {
+	p := New()
+	p.SetAudioExclusive(true)
+
+	snapshot := p.SignalPathSnapshot()
+	if snapshot.Requested != player.ModeExclusiveProcessed {
+		t.Fatalf("requested mode = %q, want exclusive_processed", snapshot.Requested)
+	}
+	if snapshot.Effective != player.EffectiveUnverified {
+		t.Fatalf("effective mode = %q, want unverified", snapshot.Effective)
+	}
+	if snapshot.IsBitPerfect() {
+		t.Fatal("an exclusive request without observations claimed bit-perfect output")
+	}
+}
+
+func TestConfiguredProcessingStagesArePublished(t *testing.T) {
+	p := New()
+	if err := p.SetVolume(80); err != nil {
+		t.Fatal(err)
+	}
+	if err := p.SetReplayGainOptions(player.ReplayGainOptions{Mode: player.ReplayGainAlbum}); err != nil {
+		t.Fatal(err)
+	}
+	p.SetPauseFade(true)
+
+	snapshot := p.SignalPathSnapshot()
+	for _, kind := range []player.ProcessingKind{
+		player.ProcessingSoftwareVolume,
+		player.ProcessingReplayGain,
+		player.ProcessingFade,
+	} {
+		if !activeProcessing(snapshot, kind) {
+			t.Fatalf("processing stage %q was not published: %#v", kind, snapshot.Processing)
+		}
+	}
+}
+
+func TestSignalPathSnapshotNeverContainsSourceURL(t *testing.T) {
+	p := New()
+	p.setCurrentSource(player.PlaybackSource{
+		URL: "https://user:secret@example.test/stream?token=private",
+		Descriptor: player.SourceDescriptor{
+			ServerID: "server",
+			TrackID:  "track",
+		},
+		Receipt: player.NewSourceReceipt(player.DeliveryRawRequested),
+	})
+
+	encoded, err := json.Marshal(p.SignalPathSnapshot())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(encoded), "secret") || strings.Contains(string(encoded), "private") {
+		t.Fatalf("snapshot leaked source credentials: %s", encoded)
+	}
+}
+
+func TestPreparedSourceIsPromotedAtTrackBoundary(t *testing.T) {
+	p := New()
+	p.setCurrentSource(player.PlaybackSource{Descriptor: player.SourceDescriptor{TrackID: "current"}})
+	p.sourceMu.Lock()
+	p.nextSource = player.PlaybackSource{Descriptor: player.SourceDescriptor{TrackID: "next"}}
+	p.haveNextSource = true
+	p.sourceMu.Unlock()
+
+	p.promoteNextSource()
+	snapshot := p.SignalPathSnapshot()
+	if snapshot.Source.TrackID != "next" {
+		t.Fatalf("track ID = %q, want next", snapshot.Source.TrackID)
+	}
+	if snapshot.Generation != 2 {
+		t.Fatalf("generation = %d, want 2", snapshot.Generation)
+	}
+}
+
+func TestLosslessCodecClassification(t *testing.T) {
+	tests := map[string]bool{
+		"flac":      true,
+		"ALAC":      true,
+		"pcm_s24le": true,
+		"wavpack":   true,
+		"mp3":       false,
+		"aac":       false,
+		"dsd_lsbf":  false,
+		"":          false,
+	}
+	for codec, want := range tests {
+		if got := isLosslessCodec(codec); got != want {
+			t.Errorf("isLosslessCodec(%q) = %t, want %t", codec, got, want)
+		}
+	}
+}
+
+func activeProcessing(snapshot player.PlaybackSnapshot, kind player.ProcessingKind) bool {
+	for _, stage := range snapshot.Processing {
+		if stage.Kind == kind {
+			return stage.Active
+		}
+	}
+	return false
+}

--- a/backend/player/player.go
+++ b/backend/player/player.go
@@ -6,8 +6,8 @@ import (
 
 type URLPlayer interface {
 	BasePlayer
-	PlayFile(url string, metadata mediaprovider.MediaItemMetadata, startTime float64) error
-	SetNextFile(url string, metadata mediaprovider.MediaItemMetadata) error
+	PlayFile(source PlaybackSource, metadata mediaprovider.MediaItemMetadata, startTime float64) error
+	SetNextFile(source PlaybackSource, metadata mediaprovider.MediaItemMetadata) error
 }
 
 type TrackPlayer interface {

--- a/backend/player/signalpath.go
+++ b/backend/player/signalpath.go
@@ -1,0 +1,359 @@
+package player
+
+import (
+	"slices"
+	"sync"
+	"time"
+)
+
+type AudioFormat struct {
+	SampleFormat string
+	SampleRate   int
+	BitDepth     int
+	Channels     int
+}
+
+type DecoderState struct {
+	Available bool
+	Codec     string
+	Bitrate   int
+	Format    AudioFormat
+	Lossless  bool
+	RawDSD    bool
+}
+
+type ProcessingKind string
+
+const (
+	ProcessingResampler      ProcessingKind = "resampler"
+	ProcessingSoftwareVolume ProcessingKind = "software_volume"
+	ProcessingReplayGain     ProcessingKind = "replay_gain"
+	ProcessingEqualizer      ProcessingKind = "equalizer"
+	ProcessingChannelMix     ProcessingKind = "channel_mix"
+	ProcessingFade           ProcessingKind = "fade"
+	ProcessingAnalyzer       ProcessingKind = "analyzer"
+)
+
+type ProcessingStage struct {
+	Kind           ProcessingKind
+	Active         bool
+	ChangesSamples bool
+	Reason         string
+}
+
+type OutputState struct {
+	Backend            string
+	DeviceID           string
+	Format             AudioFormat
+	Exclusive          bool
+	ExclusiveKnown     bool
+	FormatKnown        bool
+	ProcessingKnown    bool
+	DoP                bool
+	DoPMarkersKnown    bool
+	DoPMarkersValid    bool
+	InjectedFillFrames uint64
+}
+
+type DeviceState struct {
+	RequestedID   string
+	EffectiveID   string
+	Name          string
+	IdentityKnown bool
+}
+
+type TransparencyScope string
+
+const (
+	TransparencyNone      TransparencyScope = "none"
+	TransparencyDelivered TransparencyScope = "delivered_stream"
+	TransparencyOriginal  TransparencyScope = "original_source"
+)
+
+type PlaybackSnapshot struct {
+	Requested    RequestedMode
+	Effective    EffectiveMode
+	Verification VerificationLevel
+	Transparency TransparencyScope
+	Source       SourceDescriptor
+	Receipt      SourceReceipt
+	Decoder      DecoderState
+	Processing   []ProcessingStage
+	Output       OutputState
+	Device       DeviceState
+	Fallback     *FallbackReason
+	Issues       []FallbackReason
+	Generation   uint64
+	UpdatedAt    time.Time
+}
+
+func (s PlaybackSnapshot) Clone() PlaybackSnapshot {
+	s.Receipt = s.Receipt.Clone()
+	s.Processing = slices.Clone(s.Processing)
+	s.Issues = slices.Clone(s.Issues)
+	if s.Fallback != nil {
+		fallback := *s.Fallback
+		s.Fallback = &fallback
+	}
+	return s
+}
+
+func (s PlaybackSnapshot) IsBitPerfect() bool {
+	return (s.Effective == EffectiveStrictPCM || s.Effective == EffectiveStrictDoP || s.Effective == EffectiveNativeDSD) &&
+		s.Verification.AtLeast(VerificationObserved) && len(s.Issues) == 0 && s.Fallback == nil
+}
+
+type SignalPathObservation struct {
+	Requested        RequestedMode
+	Source           SourceDescriptor
+	Receipt          SourceReceipt
+	Decoder          DecoderState
+	Processing       []ProcessingStage
+	Output           OutputState
+	Device           DeviceState
+	RemoteRenderer   bool
+	Negotiated       bool
+	RuntimeObserved  bool
+	HardwareVerified bool
+	Fallback         *FallbackReason
+	Generation       uint64
+}
+
+// ReduceSignalPath is the only place that promotes observations into product
+// claims. Unknown facts fail closed instead of being treated as successful.
+func ReduceSignalPath(observation SignalPathObservation) PlaybackSnapshot {
+	snapshot := PlaybackSnapshot{
+		Requested:    observation.Requested,
+		Verification: verificationForObservation(observation),
+		Source:       observation.Source,
+		Receipt:      observation.Receipt.Clone(),
+		Decoder:      observation.Decoder,
+		Processing:   slices.Clone(observation.Processing),
+		Output:       observation.Output,
+		Device:       observation.Device,
+		Generation:   observation.Generation,
+		UpdatedAt:    time.Now().UTC(),
+	}
+	if observation.Fallback != nil {
+		fallback := *observation.Fallback
+		snapshot.Fallback = &fallback
+		snapshot.Effective = EffectiveFallback
+		return snapshot
+	}
+	if observation.RemoteRenderer {
+		snapshot.Effective = EffectiveRemoteRenderer
+		snapshot.Transparency = TransparencyNone
+		return snapshot
+	}
+
+	switch observation.Requested {
+	case ModeNormal:
+		snapshot.Effective = EffectiveSharedProcessed
+		if observation.Output.ExclusiveKnown && observation.Output.Exclusive {
+			snapshot.Effective = EffectiveExclusiveProcessed
+		}
+	case ModeExclusiveProcessed:
+		snapshot.Effective = reduceExclusiveProcessed(&snapshot)
+	case ModeStrict:
+		reduceStrict(&snapshot)
+	default:
+		snapshot.Effective = EffectiveUnsupported
+		snapshot.Issues = append(snapshot.Issues, FallbackReason{
+			Code:   FallbackEffectiveModeUnknown,
+			Detail: "unknown requested playback mode",
+		})
+	}
+	return snapshot
+}
+
+func verificationForObservation(observation SignalPathObservation) VerificationLevel {
+	switch {
+	case observation.HardwareVerified:
+		return VerificationHardwareVerified
+	case observation.RuntimeObserved:
+		return VerificationObserved
+	case observation.Negotiated:
+		return VerificationNegotiated
+	default:
+		return VerificationConfigured
+	}
+}
+
+func reduceExclusiveProcessed(snapshot *PlaybackSnapshot) EffectiveMode {
+	if !snapshot.Output.ExclusiveKnown {
+		snapshot.Issues = append(snapshot.Issues, FallbackReason{
+			Code:   FallbackEffectiveModeUnknown,
+			Detail: "the output backend has not reported effective exclusive state",
+		})
+		return EffectiveUnverified
+	}
+	if !snapshot.Output.Exclusive {
+		snapshot.Fallback = &FallbackReason{
+			Code:   FallbackExclusiveDenied,
+			Detail: "the output backend is not exclusive",
+		}
+		return EffectiveFallback
+	}
+	return EffectiveExclusiveProcessed
+}
+
+func reduceStrict(snapshot *PlaybackSnapshot) {
+	if snapshot.Decoder.RawDSD || snapshot.Receipt.RawDSD {
+		snapshot.Issues = strictDoPIssues(*snapshot)
+		if len(snapshot.Issues) == 0 && snapshot.Verification.AtLeast(VerificationObserved) {
+			snapshot.Effective = EffectiveStrictDoP
+			snapshot.Transparency = transparencyForReceipt(snapshot.Receipt)
+			return
+		}
+	} else {
+		snapshot.Issues = strictPCMIssues(*snapshot)
+		if len(snapshot.Issues) == 0 && snapshot.Verification.AtLeast(VerificationObserved) {
+			snapshot.Effective = EffectiveStrictPCM
+			snapshot.Transparency = transparencyForReceipt(snapshot.Receipt)
+			return
+		}
+	}
+	if len(snapshot.Issues) == 0 {
+		snapshot.Issues = append(snapshot.Issues, FallbackReason{
+			Code:   FallbackEffectiveModeUnknown,
+			Detail: "strict playback has not been observed at runtime",
+		})
+	}
+	snapshot.Effective = EffectiveStrictUnverified
+}
+
+func strictPCMIssues(snapshot PlaybackSnapshot) []FallbackReason {
+	issues := make([]FallbackReason, 0, 4)
+	if !snapshot.Decoder.Available {
+		issues = append(issues, FallbackReason{Code: FallbackEffectiveModeUnknown, Detail: "decoder output is unknown"})
+	} else if !snapshot.Decoder.Lossless {
+		issues = append(issues, FallbackReason{Code: FallbackSourceLossy, Detail: "decoder output is not known lossless PCM"})
+	}
+	issues = append(issues, strictOutputIssues(snapshot)...)
+	return issues
+}
+
+func strictDoPIssues(snapshot PlaybackSnapshot) []FallbackReason {
+	issues := make([]FallbackReason, 0, 4)
+	if !snapshot.Decoder.RawDSD && !snapshot.Receipt.RawDSD {
+		issues = append(issues, FallbackReason{Code: FallbackRawDSDUnavailable, Detail: "raw DSD source is unavailable"})
+	}
+	if !snapshot.Output.DoP {
+		issues = append(issues, FallbackReason{Code: FallbackDoPCarrierUnsupported, Detail: "DoP carrier is not active"})
+	}
+	if !snapshot.Output.DoPMarkersKnown || !snapshot.Output.DoPMarkersValid {
+		issues = append(issues, FallbackReason{Code: FallbackEffectiveModeUnknown, Detail: "DoP marker continuity is not verified"})
+	}
+	if snapshot.Output.InjectedFillFrames > 0 {
+		issues = append(issues, FallbackReason{Code: FallbackUnderrunFillInjected, Detail: "the output contains injected DoP mute frames"})
+	}
+	issues = append(issues, strictOutputIssues(snapshot)...)
+	return issues
+}
+
+func strictOutputIssues(snapshot PlaybackSnapshot) []FallbackReason {
+	issues := make([]FallbackReason, 0, 6)
+	if !snapshot.Output.ExclusiveKnown {
+		issues = append(issues, FallbackReason{Code: FallbackEffectiveModeUnknown, Detail: "effective exclusive state is unknown"})
+	} else if !snapshot.Output.Exclusive {
+		issues = append(issues, FallbackReason{Code: FallbackExclusiveDenied, Detail: "the output backend is not exclusive"})
+	}
+	if !snapshot.Device.IdentityKnown {
+		issues = append(issues, FallbackReason{Code: FallbackDeviceMissing, Detail: "effective device identity is unknown"})
+	} else if snapshot.Device.RequestedID != "" && snapshot.Device.RequestedID != snapshot.Device.EffectiveID {
+		issues = append(issues, FallbackReason{Code: FallbackDeviceMissing, Detail: "effective device differs from the requested device"})
+	}
+	if !snapshot.Output.FormatKnown {
+		issues = append(issues, FallbackReason{Code: FallbackEffectiveModeUnknown, Detail: "effective output format is unknown"})
+	} else if snapshot.Decoder.Available && !snapshot.Decoder.RawDSD {
+		if snapshot.Decoder.Format.SampleRate != snapshot.Output.Format.SampleRate {
+			issues = append(issues, FallbackReason{Code: FallbackRateMismatch, Detail: "decoder and output sample rates differ"})
+		}
+		if snapshot.Decoder.Format.BitDepth != snapshot.Output.Format.BitDepth {
+			issues = append(issues, FallbackReason{Code: FallbackBitDepthMismatch, Detail: "decoder and output bit depths differ"})
+		}
+		if snapshot.Decoder.Format.Channels != snapshot.Output.Format.Channels {
+			issues = append(issues, FallbackReason{Code: FallbackChannelMappingRequired, Detail: "decoder and output channel counts differ"})
+		}
+	}
+	if !snapshot.Output.ProcessingKnown {
+		issues = append(issues, FallbackReason{Code: FallbackEffectiveModeUnknown, Detail: "active processing stages are unknown"})
+	} else {
+		for _, stage := range snapshot.Processing {
+			if stage.Active && stage.ChangesSamples {
+				issues = append(issues, reasonForProcessing(stage))
+			}
+		}
+	}
+	return issues
+}
+
+func reasonForProcessing(stage ProcessingStage) FallbackReason {
+	code := FallbackFilterActive
+	switch stage.Kind {
+	case ProcessingResampler:
+		code = FallbackResamplerActive
+	case ProcessingSoftwareVolume, ProcessingReplayGain, ProcessingFade:
+		code = FallbackSoftwareGainActive
+	case ProcessingChannelMix:
+		code = FallbackChannelMappingRequired
+	}
+	return FallbackReason{Code: code, Detail: stage.Reason}
+}
+
+func transparencyForReceipt(receipt SourceReceipt) TransparencyScope {
+	if receipt.Provenance == ProvenanceOriginalConfirmed {
+		return TransparencyOriginal
+	}
+	return TransparencyDelivered
+}
+
+// SignalPathState owns an immutable current snapshot. Callbacks are invoked
+// after releasing the lock and receive independent copies.
+type SignalPathState struct {
+	mu        sync.RWMutex
+	snapshot  PlaybackSnapshot
+	callbacks []func(PlaybackSnapshot)
+}
+
+func NewSignalPathState(initial PlaybackSnapshot) *SignalPathState {
+	if initial.UpdatedAt.IsZero() {
+		initial.UpdatedAt = time.Now().UTC()
+	}
+	return &SignalPathState{snapshot: initial.Clone()}
+}
+
+func (s *SignalPathState) Snapshot() PlaybackSnapshot {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.snapshot.Clone()
+}
+
+func (s *SignalPathState) Update(update func(*PlaybackSnapshot)) {
+	s.mu.Lock()
+	next := s.snapshot.Clone()
+	update(&next)
+	next.UpdatedAt = time.Now().UTC()
+	s.snapshot = next.Clone()
+	callbacks := slices.Clone(s.callbacks)
+	s.mu.Unlock()
+
+	for _, callback := range callbacks {
+		callback(next.Clone())
+	}
+}
+
+func (s *SignalPathState) OnChange(callback func(PlaybackSnapshot)) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if callback == nil {
+		s.callbacks = nil
+		return
+	}
+	s.callbacks = append(s.callbacks, callback)
+}
+
+type SignalPathProvider interface {
+	SignalPathSnapshot() PlaybackSnapshot
+	OnSignalPathChange(func(PlaybackSnapshot))
+}

--- a/backend/player/signalpath_test.go
+++ b/backend/player/signalpath_test.go
@@ -1,0 +1,228 @@
+package player
+
+import (
+	"testing"
+	"time"
+)
+
+func TestReduceSignalPathCurrentModes(t *testing.T) {
+	tests := []struct {
+		name         string
+		observation  SignalPathObservation
+		wantMode     EffectiveMode
+		wantVerified VerificationLevel
+		wantIssue    FallbackReasonCode
+	}{
+		{
+			name:         "normal is processed shared playback",
+			observation:  SignalPathObservation{Requested: ModeNormal},
+			wantMode:     EffectiveSharedProcessed,
+			wantVerified: VerificationConfigured,
+		},
+		{
+			name:         "exclusive request without observation is unverified",
+			observation:  SignalPathObservation{Requested: ModeExclusiveProcessed},
+			wantMode:     EffectiveUnverified,
+			wantVerified: VerificationConfigured,
+			wantIssue:    FallbackEffectiveModeUnknown,
+		},
+		{
+			name: "observed exclusive processed",
+			observation: SignalPathObservation{
+				Requested:       ModeExclusiveProcessed,
+				RuntimeObserved: true,
+				Output:          OutputState{ExclusiveKnown: true, Exclusive: true},
+			},
+			wantMode:     EffectiveExclusiveProcessed,
+			wantVerified: VerificationObserved,
+		},
+		{
+			name: "exclusive rejection is visible fallback",
+			observation: SignalPathObservation{
+				Requested: ModeExclusiveProcessed,
+				Output:    OutputState{ExclusiveKnown: true},
+			},
+			wantMode:     EffectiveFallback,
+			wantVerified: VerificationConfigured,
+		},
+		{
+			name: "remote renderer never claims the local DAC path",
+			observation: SignalPathObservation{
+				Requested:      ModeNormal,
+				RemoteRenderer: true,
+			},
+			wantMode:     EffectiveRemoteRenderer,
+			wantVerified: VerificationConfigured,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			snapshot := ReduceSignalPath(test.observation)
+			if snapshot.Effective != test.wantMode {
+				t.Fatalf("effective mode = %q, want %q", snapshot.Effective, test.wantMode)
+			}
+			if snapshot.Verification != test.wantVerified {
+				t.Fatalf("verification = %q, want %q", snapshot.Verification, test.wantVerified)
+			}
+			if test.wantIssue != "" && !hasIssue(snapshot, test.wantIssue) {
+				t.Fatalf("issues = %#v, want %q", snapshot.Issues, test.wantIssue)
+			}
+			if snapshot.IsBitPerfect() {
+				t.Fatal("current playback mode unexpectedly claimed bit-perfect output")
+			}
+		})
+	}
+}
+
+func TestReduceSignalPathStrictPCMRequiresEveryObservedInvariant(t *testing.T) {
+	base := strictPCMObservation()
+	tests := []struct {
+		name      string
+		mutate    func(*SignalPathObservation)
+		wantIssue FallbackReasonCode
+	}{
+		{"decoder unavailable", func(o *SignalPathObservation) { o.Decoder.Available = false }, FallbackEffectiveModeUnknown},
+		{"lossy decoder", func(o *SignalPathObservation) { o.Decoder.Lossless = false }, FallbackSourceLossy},
+		{"exclusive unknown", func(o *SignalPathObservation) { o.Output.ExclusiveKnown = false }, FallbackEffectiveModeUnknown},
+		{"exclusive denied", func(o *SignalPathObservation) { o.Output.Exclusive = false }, FallbackExclusiveDenied},
+		{"device unknown", func(o *SignalPathObservation) { o.Device.IdentityKnown = false }, FallbackDeviceMissing},
+		{"wrong device", func(o *SignalPathObservation) { o.Device.EffectiveID = "other" }, FallbackDeviceMissing},
+		{"format unknown", func(o *SignalPathObservation) { o.Output.FormatKnown = false }, FallbackEffectiveModeUnknown},
+		{"rate mismatch", func(o *SignalPathObservation) { o.Output.Format.SampleRate = 48000 }, FallbackRateMismatch},
+		{"bit depth mismatch", func(o *SignalPathObservation) { o.Output.Format.BitDepth = 16 }, FallbackBitDepthMismatch},
+		{"channels mismatch", func(o *SignalPathObservation) { o.Output.Format.Channels = 1 }, FallbackChannelMappingRequired},
+		{"processing unknown", func(o *SignalPathObservation) { o.Output.ProcessingKnown = false }, FallbackEffectiveModeUnknown},
+		{"resampler active", func(o *SignalPathObservation) {
+			o.Processing = []ProcessingStage{{Kind: ProcessingResampler, Active: true, ChangesSamples: true}}
+		}, FallbackResamplerActive},
+		{"software gain active", func(o *SignalPathObservation) {
+			o.Processing = []ProcessingStage{{Kind: ProcessingReplayGain, Active: true, ChangesSamples: true}}
+		}, FallbackSoftwareGainActive},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			observation := base
+			test.mutate(&observation)
+			snapshot := ReduceSignalPath(observation)
+			if snapshot.Effective != EffectiveStrictUnverified {
+				t.Fatalf("effective = %q, want strict_unverified", snapshot.Effective)
+			}
+			if !hasIssue(snapshot, test.wantIssue) {
+				t.Fatalf("issues = %#v, want %q", snapshot.Issues, test.wantIssue)
+			}
+			if snapshot.IsBitPerfect() {
+				t.Fatal("failed invariant still produced a bit-perfect claim")
+			}
+		})
+	}
+}
+
+func TestReduceSignalPathPromotesOnlyObservedStrictPCM(t *testing.T) {
+	configured := strictPCMObservation()
+	configured.RuntimeObserved = false
+	configured.Negotiated = true
+	if snapshot := ReduceSignalPath(configured); snapshot.Effective != EffectiveStrictUnverified {
+		t.Fatalf("negotiated-only mode = %q, want strict_unverified", snapshot.Effective)
+	}
+
+	observed := strictPCMObservation()
+	snapshot := ReduceSignalPath(observed)
+	if snapshot.Effective != EffectiveStrictPCM || !snapshot.IsBitPerfect() {
+		t.Fatalf("observed strict snapshot was not promoted: %#v", snapshot)
+	}
+	if snapshot.Transparency != TransparencyOriginal {
+		t.Fatalf("transparency = %q, want original_source", snapshot.Transparency)
+	}
+
+	observed.Receipt.Provenance = ProvenanceDeliveredOnly
+	snapshot = ReduceSignalPath(observed)
+	if !snapshot.IsBitPerfect() || snapshot.Transparency != TransparencyDelivered {
+		t.Fatalf("delivered-stream transparency was not retained: %#v", snapshot)
+	}
+}
+
+func TestReduceSignalPathDoPRejectsBadMarkersAndFill(t *testing.T) {
+	observation := strictPCMObservation()
+	observation.Decoder.RawDSD = true
+	observation.Receipt.RawDSD = true
+	observation.Output.DoP = true
+	observation.Output.DoPMarkersKnown = true
+	observation.Output.DoPMarkersValid = true
+	observation.Output.InjectedFillFrames = 1
+
+	snapshot := ReduceSignalPath(observation)
+	if snapshot.Effective != EffectiveStrictUnverified || !hasIssue(snapshot, FallbackUnderrunFillInjected) {
+		t.Fatalf("DoP fill did not invalidate strict state: %#v", snapshot)
+	}
+
+	observation.Output.InjectedFillFrames = 0
+	snapshot = ReduceSignalPath(observation)
+	if snapshot.Effective != EffectiveStrictDoP || !snapshot.IsBitPerfect() {
+		t.Fatalf("valid observed DoP was not promoted: %#v", snapshot)
+	}
+}
+
+func TestSignalPathStatePublishesIndependentSnapshots(t *testing.T) {
+	state := NewSignalPathState(PlaybackSnapshot{
+		Processing: []ProcessingStage{{Kind: ProcessingAnalyzer}},
+	})
+	callbackRan := make(chan PlaybackSnapshot, 1)
+	state.OnChange(func(snapshot PlaybackSnapshot) {
+		snapshot.Processing[0].Kind = ProcessingEqualizer
+		callbackRan <- snapshot
+	})
+
+	state.Update(func(snapshot *PlaybackSnapshot) {
+		snapshot.Generation = 2
+	})
+
+	select {
+	case <-callbackRan:
+	case <-time.After(time.Second):
+		t.Fatal("signal-path callback did not run")
+	}
+	current := state.Snapshot()
+	if current.Generation != 2 {
+		t.Fatalf("generation = %d, want 2", current.Generation)
+	}
+	if current.Processing[0].Kind != ProcessingAnalyzer {
+		t.Fatal("callback mutated the stored snapshot")
+	}
+}
+
+func strictPCMObservation() SignalPathObservation {
+	format := AudioFormat{SampleFormat: "s32", SampleRate: 96000, BitDepth: 24, Channels: 2}
+	return SignalPathObservation{
+		Requested: ModeStrict,
+		Receipt: SourceReceipt{
+			Provenance:        ProvenanceOriginalConfirmed,
+			DeliveredLossless: true,
+			LosslessKnown:     true,
+		},
+		Decoder: DecoderState{Available: true, Lossless: true, Format: format},
+		Output: OutputState{
+			Exclusive:       true,
+			ExclusiveKnown:  true,
+			Format:          format,
+			FormatKnown:     true,
+			ProcessingKnown: true,
+		},
+		Device: DeviceState{
+			RequestedID:   "dac",
+			EffectiveID:   "dac",
+			IdentityKnown: true,
+		},
+		RuntimeObserved: true,
+	}
+}
+
+func hasIssue(snapshot PlaybackSnapshot, code FallbackReasonCode) bool {
+	for _, issue := range snapshot.Issues {
+		if issue.Code == code {
+			return true
+		}
+	}
+	return snapshot.Fallback != nil && snapshot.Fallback.Code == code
+}

--- a/backend/player/source.go
+++ b/backend/player/source.go
@@ -1,0 +1,95 @@
+package player
+
+import "slices"
+
+// DeliveryPolicy records how the client asked the media provider to deliver a
+// source. It must not be inferred later from a signed URL.
+type DeliveryPolicy string
+
+const (
+	DeliveryRawRequested       DeliveryPolicy = "raw"
+	DeliveryTranscodeRequested DeliveryPolicy = "transcode_requested"
+	DeliveryServerDefault      DeliveryPolicy = "server_default"
+	DeliveryExternalStream     DeliveryPolicy = "external_stream"
+	DeliveryRemoteControlled   DeliveryPolicy = "remote_controlled"
+)
+
+type SourceProvenance string
+
+const (
+	ProvenanceUnknown             SourceProvenance = "unknown"
+	ProvenanceOriginalConfirmed   SourceProvenance = "original_confirmed"
+	ProvenanceTranscodedConfirmed SourceProvenance = "transcoded_confirmed"
+	ProvenanceDeliveredOnly       SourceProvenance = "delivered_only"
+)
+
+type EvidenceItem struct {
+	Kind  string
+	Value string
+}
+
+// SourceDescriptor contains server-library metadata. These fields describe the
+// stored object and must not be presented as facts about delivered bytes.
+type SourceDescriptor struct {
+	ServerID        string
+	TrackID         string
+	LibraryCodec    string
+	LibrarySuffix   string
+	LibrarySize     int64
+	LibraryRate     int
+	LibraryBits     int
+	LibraryChannels int
+}
+
+// SourceReceipt contains evidence about the bytes delivered for one playback
+// request. URLs and credentials are deliberately excluded.
+type SourceReceipt struct {
+	DeliveryPolicy     DeliveryPolicy
+	Provenance         SourceProvenance
+	DeliveredCodec     string
+	Container          string
+	DeliveredRate      int
+	DeliveredBits      int
+	DeliveredChannels  int
+	ContentLength      int64
+	RangeSupported     bool
+	CompleteCache      bool
+	DeliveredLossless  bool
+	LosslessKnown      bool
+	RawDSD             bool
+	ContentFingerprint string
+	Evidence           []EvidenceItem
+}
+
+// PlaybackSource keeps the transport URL beside, but outside, the immutable
+// diagnostic receipt. Snapshots copy only Descriptor and Receipt.
+type PlaybackSource struct {
+	URL        string
+	Descriptor SourceDescriptor
+	Receipt    SourceReceipt
+}
+
+func (r SourceReceipt) Clone() SourceReceipt {
+	r.Evidence = slices.Clone(r.Evidence)
+	return r
+}
+
+func (s PlaybackSource) Clone() PlaybackSource {
+	s.Receipt = s.Receipt.Clone()
+	return s
+}
+
+func NewSourceReceipt(policy DeliveryPolicy) SourceReceipt {
+	provenance := ProvenanceUnknown
+	if policy == DeliveryTranscodeRequested {
+		provenance = ProvenanceTranscodedConfirmed
+	}
+	return SourceReceipt{
+		DeliveryPolicy: policy,
+		Provenance:     provenance,
+		Evidence: []EvidenceItem{{
+			Kind:  "delivery_policy",
+			Value: string(policy),
+		}},
+	}
+}

--- a/backend/player/source_test.go
+++ b/backend/player/source_test.go
@@ -1,0 +1,39 @@
+package player
+
+import "testing"
+
+func TestNewSourceReceiptRecordsOnlyContractualProvenance(t *testing.T) {
+	tests := []struct {
+		policy     DeliveryPolicy
+		provenance SourceProvenance
+	}{
+		{DeliveryRawRequested, ProvenanceUnknown},
+		{DeliveryTranscodeRequested, ProvenanceTranscodedConfirmed},
+		{DeliveryServerDefault, ProvenanceUnknown},
+		{DeliveryExternalStream, ProvenanceUnknown},
+		{DeliveryRemoteControlled, ProvenanceUnknown},
+	}
+	for _, test := range tests {
+		t.Run(string(test.policy), func(t *testing.T) {
+			receipt := NewSourceReceipt(test.policy)
+			if receipt.DeliveryPolicy != test.policy {
+				t.Fatalf("delivery policy = %q, want %q", receipt.DeliveryPolicy, test.policy)
+			}
+			if receipt.Provenance != test.provenance {
+				t.Fatalf("provenance = %q, want %q", receipt.Provenance, test.provenance)
+			}
+			if len(receipt.Evidence) != 1 || receipt.Evidence[0].Value != string(test.policy) {
+				t.Fatalf("unexpected policy evidence: %#v", receipt.Evidence)
+			}
+		})
+	}
+}
+
+func TestPlaybackSourceCloneDoesNotShareEvidence(t *testing.T) {
+	original := PlaybackSource{Receipt: NewSourceReceipt(DeliveryRawRequested)}
+	clone := original.Clone()
+	clone.Receipt.Evidence[0].Value = "changed"
+	if original.Receipt.Evidence[0].Value != string(DeliveryRawRequested) {
+		t.Fatal("clone mutated the original receipt evidence")
+	}
+}

--- a/ui/browsing/nowplayingpage.go
+++ b/ui/browsing/nowplayingpage.go
@@ -615,6 +615,10 @@ func (a *NowPlayingPage) formatStatusLine() {
 }
 
 func (a *NowPlayingPage) formatMediaInfoStr(player player.BasePlayer) string {
+	if decoder := a.pm.SignalPathSnapshot().Decoder; decoder.Available {
+		return formatMediaInfo(decoder.Codec, decoder.Format.SampleRate, decoder.Bitrate)
+	}
+
 	mpv, ok := player.(*mpv.Player)
 	if !ok {
 		return ""
@@ -624,12 +628,15 @@ func (a *NowPlayingPage) formatMediaInfoStr(player player.BasePlayer) string {
 		log.Printf("error getting playback status: %s", err.Error())
 		return ""
 	}
-	codec := audioInfo.Codec
+	return formatMediaInfo(audioInfo.Codec, audioInfo.Samplerate, audioInfo.Bitrate)
+}
+
+func formatMediaInfo(codec string, sampleRate, bitrate int) string {
 	if len(codec) <= 4 && !strings.EqualFold(codec, "opus") {
 		codec = strings.ToUpper(codec) // FLAC, MP3, AAC, etc
 	}
 
 	// Note: bit depth intentionally omitted since MPV reports the decoded bit depth
 	// i.e. 24 bit files get reported as 32 bit. Also b/c bit depth isn't meaningful for lossy.
-	return fmt.Sprintf("%s %g kHz, %d kbps", codec, float64(audioInfo.Samplerate)/1000, audioInfo.Bitrate/1000)
+	return fmt.Sprintf("%s %g kHz, %d kbps", codec, float64(sampleRate)/1000, bitrate/1000)
 }


### PR DESCRIPTION
Supersonic currently records requested playback options, but it has no shared model for distinguishing those requests from the signal path that a backend actually observes. That makes future exclusive and bit-perfect UI easy to overstate, and raw/transcoded/default stream intent is lost once playback receives a URL.

This adds the behavior-preserving foundation for truthful playback reporting:

- typed requested/effective modes, verification levels, capabilities, processing stages, source descriptors, and redacted source receipts
- one fail-closed reducer responsible for strict PCM/DoP claims and stable fallback reasons
- immutable signal-path snapshots for mpv, DLNA, and Jukebox
- typed playback sources so stream-delivery policy survives URL resolution without exposing credentials in diagnostics
- the existing Now Playing codec/rate display reads the snapshot while preserving its current output

No strict mode is enabled by this PR. Current mpv exclusive playback remains explicitly unverified until libmpv can report effective output facts; remote renderers never claim the local DAC path.

Validation:

- `go test ./...`
- `go test -race ./backend/player/...`
- `golangci-lint run`
- `go build -tags migrated_fynedo -o /tmp/supersonic-audiophile-phase1 ./`
