### PR TITLE
Fix waveform seekbar staying stuck when playing radio after app restart

### DIFF
--- a/backend/playbackengine.go
+++ b/backend/playbackengine.go
@@ -112,16 +112,24 @@ type playbackEngine struct {
 
 	// registered callbacks
 	onBeforeSongChange []func(next mediaprovider.MediaItem)
-	onSongChange       []func(nowPlaying mediaprovider.MediaItem, justScrobbledIfAny *mediaprovider.Track)
-	onPlayTimeUpdate   []func(float64, float64, bool)
-	onLoopModeChange   []func(LoopMode)
-	onShuffleChange    []func(bool)
-	onVolumeChange     []func(int)
-	onSeek             []func()
-	onPaused           []func()
-	onStopped          []func()
-	onPlaying          []func()
-	onQueueChange      []func()
+	// fired exactly once, from loadTrackPaused, for the track that is being
+	// loaded paused (e.g. restoring playback state on app startup). Unlike
+	// onBeforeSongChange, this is never fired again for next-up/precache
+	// purposes, so consumers can safely use it to know "this is the track
+	// that was paused-loaded at startup" without it being retriggered by
+	// later, unrelated onBeforeSongChange calls (e.g. from handleNextTrackUpdated)
+	// while pendingLoadPaused is still true.
+	onLoadTrackPaused []func(item mediaprovider.MediaItem)
+	onSongChange      []func(nowPlaying mediaprovider.MediaItem, justScrobbledIfAny *mediaprovider.Track)
+	onPlayTimeUpdate  []func(float64, float64, bool)
+	onLoopModeChange  []func(LoopMode)
+	onShuffleChange   []func(bool)
+	onVolumeChange    []func(int)
+	onSeek            []func()
+	onPaused          []func()
+	onStopped         []func()
+	onPlaying         []func()
+	onQueueChange     []func()
 
 	onRadioMetadataChange []func(radioName, title, artist string)
 }
@@ -337,6 +345,9 @@ func (p *playbackEngine) loadTrackPaused(idx int, startTime float64) error {
 	// Pre-generate the waveform image for the paused track using the same hook
 	// that normally pre-generates waveforms for the upcoming track.
 	for _, cb := range p.onBeforeSongChange {
+		cb(nowPlaying)
+	}
+	for _, cb := range p.onLoadTrackPaused {
 		cb(nowPlaying)
 	}
 
@@ -867,7 +878,7 @@ func (p *playbackEngine) cacheNextTracks() {
 		// the "currently" playing track, since we're probably about to play it
 		npI := max(p.nowPlayingIdx, 0)
 		for _, idx := range [3]int{npI, npI + 1, npI + 2} {
-			if idx > 0 && idx < p.getPlayQueueLength() {
+			if idx >= 0 && idx < p.getPlayQueueLength() {
 				item := p.getPlayQueueItemAt(idx)
 				if item.Metadata().Type == mediaprovider.MediaItemTypeTrack {
 					fetch = append(fetch, AudioCacheRequest{

--- a/backend/playbackmanager.go
+++ b/backend/playbackmanager.go
@@ -136,12 +136,15 @@ func (p *PlaybackManager) addOnTrackChangeHook() {
 				p.addWfmImageJob(p.wfmGen.StartWaveformGeneration(item.(*mediaprovider.Track)))
 			}
 		}
-		if p.isLoadTrackPaused() {
-			// we need to call handleWaveformImageSongChange to ensure the waveform image is updated
-			// for the track that is loaded paused when starting the app
-			p.handleWaveformImageSongChange(item)
-			p.wasLoadTrackPaused = true
+	})
+	p.engine.onLoadTrackPaused = append(p.engine.onLoadTrackPaused, func(item mediaprovider.MediaItem) {
+		if item == nil || !p.engine.playbackCfg.UseWaveformSeekbar {
+			return
 		}
+		// we need to call handleWaveformImageSongChange here to ensure the waveform image is updated
+		// for the track that is loaded paused when starting the app
+		p.handleWaveformImageSongChange(item)
+		p.wasLoadTrackPaused = true
 	})
 
 	p.OnSongChange(func(item mediaprovider.MediaItem, _ *mediaprovider.Track) {
@@ -554,10 +557,6 @@ func (p *PlaybackManager) PlayTrackAt(idx int) {
 // starting MPV. Call Continue (or PlayPause) to begin actual playback.
 func (p *PlaybackManager) LoadTrackPaused(idx int, startTime float64) {
 	p.cmdQueue.LoadTrackPaused(idx, startTime)
-}
-
-func (p *PlaybackManager) isLoadTrackPaused() bool {
-	return p.engine.pendingLoadPaused
 }
 
 func (p *PlaybackManager) PlayRandomSongs(genreName string) error {


### PR DESCRIPTION
Fixes #1016

### Problem

With "Use waveform seekbar" enabled: if Supersonic is closed while a normal track is loaded, then restarted (last track shown paused, waveform correctly rendered), starting an internet radio station afterwards leaves the *previous* track's waveform image displayed instead of clearing it — even though radio streams have no waveform. This only happens right after a restart; under normal operation switching to radio clears/switches the display correctly.

### Root cause

Two related bugs, both around restoring a paused track on startup (`LoadTrackPaused`):

1. **Stale flag causes waveform update to be skipped.** `onBeforeSongChange` was overloaded for two purposes: (a) pre-generating a waveform image for the next-up track, and (b) detecting the special "just loaded paused at startup" case via `engine.pendingLoadPaused`. Because `loadTrackPaused()` also calls `handleNextTrackUpdated()` (to pre-cache the *next* queued track), and `pendingLoadPaused` is still `true` at that point, the "startup" branch fired a second time for the wrong item (the next-up track instead of the current one), leaving `wasLoadTrackPaused` stuck at `true`. That stale flag then made the *next* real `OnSongChange` event (e.g. starting an internet radio station) wrongly skip updating the waveform display, so the previous track's waveform stayed on screen.

   Fix: split the overloaded hook into two — `onBeforeSongChange` keeps its precache-only purpose, and a new `onLoadTrackPaused` hook fires exactly once, directly from `loadTrackPaused`, for the actual now-playing item. It can no longer be retriggered by unrelated precache calls.

2. **Previously-masked off-by-one in `cacheNextTracks()`.** With the double-invocation above removed, a second, previously-masked bug became visible: `cacheNextTracks()` only requests caching for play-queue indices `> 0`, excluding index 0. Since waveform generation piggybacks on the audio cache download (it waits for `AudioCache.CacheFile()` to have been called for the track), the currently-loaded-paused track's waveform would never start generating if that track happened to be at queue index 0 (e.g. the only track in the queue). Previously this was masked because bug (1) would coincidentally kick off caching/generation for the *next* track and display that instead. Fixed the off-by-one (`idx > 0` → `idx >= 0`) so the current track is always included.

### Testing

- `go build ./...`, `go vet ./backend/...`, `go test ./backend/...` all pass.
- Manually reasoned through both the single-track-queue and multi-track-queue startup scenarios to confirm the waveform is now generated/displayed for the correct (current) track exactly once, and correctly clears when switching to a radio station.
