### PR TITLE
Improve Linux DLNA renderer discovery for WiiM/LinkPlay players

### DIFF
--- a/backend/config.go
+++ b/backend/config.go
@@ -61,6 +61,9 @@ type AppConfig struct {
 	ShowSidebar                 bool
 	SidebarWidthFraction        float64
 	SidebarTab                  string
+	UseDefaultSSDPInterface     bool
+	SSDPInterfaceName           string
+	DLNARendererURLs            string
 
 	PreventScreensaverOnNowPlayingPage bool
 
@@ -136,7 +139,7 @@ type LocalPlaybackConfig struct {
 	InMemoryCacheSizeMB   int
 	Volume                int
 	EqualizerEnabled      bool
-	EqualizerType         string    // "ISO10Band" or "ISO15Band"
+	EqualizerType         string // "ISO10Band" or "ISO15Band"
 	EqualizerPreamp       float64
 	GraphicEqualizerBands []float64
 	ActiveEQPresetName    string // Name of currently selected EQ preset
@@ -224,6 +227,7 @@ func DefaultConfig(appVersionTag string) *Config {
 			RequestTimeoutSeconds:              15,
 			EnableOSMediaPlayerAPIs:            true,
 			SidebarWidthFraction:               0.8,
+			UseDefaultSSDPInterface:            true,
 			PreventScreensaverOnNowPlayingPage: false,
 		},
 		AlbumPage: AlbumPageConfig{
@@ -319,6 +323,11 @@ func ReadConfigFile(filepath, appVersionTag string) (*Config, error) {
 		return nil, err
 	}
 	c.migrateDeprecatedSettings()
+	// Older configs do not contain the SSDP settings. An empty interface name
+	// cannot represent an explicit selection, so preserve the default behavior.
+	if c.Application.SSDPInterfaceName == "" {
+		c.Application.UseDefaultSSDPInterface = true
+	}
 
 	// Backfill Subsonic to empty ServerType fields
 	// for updating configs created before multiple MediaProviders were added

--- a/backend/dlnadiscovery.go
+++ b/backend/dlnadiscovery.go
@@ -1,0 +1,80 @@
+package backend
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"os/exec"
+	"runtime"
+	"strings"
+)
+
+// DiscoveredDLNARenderer is a renderer found through a local service
+// discovery mechanism.
+type DiscoveredDLNARenderer struct {
+	Name string
+	URL  string
+}
+
+// DiscoverDLNARenderers combines the normal SSDP search with an Avahi fallback
+// on Linux. The fallback is needed for devices such as the WiiM Pro that
+// advertise LinkPlay via mDNS but do not answer SSDP M-SEARCH requests.
+func DiscoverDLNARenderers(ctx context.Context, appCfg *AppConfig) ([]DiscoveredDLNARenderer, error) {
+	devices := searchMediaRenderers(ctx, 1, appCfg)
+	seen := make(map[string]bool, len(devices))
+	renderers := make([]DiscoveredDLNARenderer, 0, len(devices))
+	for _, renderer := range devices {
+		seen[renderer.URL] = true
+		renderers = append(renderers, DiscoveredDLNARenderer{
+			Name: renderer.FriendlyName,
+			URL:  renderer.URL,
+		})
+	}
+
+	if runtime.GOOS != "linux" {
+		return renderers, nil
+	}
+
+	if _, err := exec.LookPath("avahi-browse"); err != nil {
+		if len(renderers) > 0 {
+			return renderers, nil
+		}
+		return nil, fmt.Errorf("avahi-browse is unavailable: %w", err)
+	}
+	cmd := exec.CommandContext(ctx, "avahi-browse", "-prt", "_linkplay._tcp")
+	output, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("avahi-browse failed: %w", err)
+	}
+	for _, renderer := range parseAvahiLinkPlayOutput(string(output)) {
+		if !seen[renderer.URL] {
+			seen[renderer.URL] = true
+			renderers = append(renderers, renderer)
+		}
+	}
+	return renderers, nil
+}
+
+func parseAvahiLinkPlayOutput(output string) []DiscoveredDLNARenderer {
+	seen := make(map[string]bool)
+	var renderers []DiscoveredDLNARenderer
+	scanner := bufio.NewScanner(strings.NewReader(output))
+	for scanner.Scan() {
+		fields := strings.Split(scanner.Text(), ";")
+		if len(fields) < 8 || fields[0] != "=" || fields[2] != "IPv4" {
+			continue
+		}
+		name := fields[3]
+		address := fields[6]
+		if name == "" || address == "" {
+			continue
+		}
+		url := "http://" + address + ":49152/description.xml"
+		if seen[url] {
+			continue
+		}
+		seen[url] = true
+		renderers = append(renderers, DiscoveredDLNARenderer{Name: name, URL: url})
+	}
+	return renderers
+}

--- a/backend/dlnadiscovery_test.go
+++ b/backend/dlnadiscovery_test.go
@@ -1,0 +1,17 @@
+package backend
+
+import "testing"
+
+func TestParseAvahiLinkPlayOutput(t *testing.T) {
+	output := `=;wlan0;IPv4;Kitchen Speaker;_linkplay._tcp;local;192.0.2.42;59152;"upnp=1.0.0"
+=;wlan0;IPv6;Kitchen Speaker;_linkplay._tcp;local;Kitchen-Speaker.local;59152;"upnp=1.0.0"
+=;wlan0;IPv4;Kitchen Speaker;_linkplay._tcp;local;192.0.2.42;59152;"upnp=1.0.0"`
+
+	renderers := parseAvahiLinkPlayOutput(output)
+	if len(renderers) != 1 {
+		t.Fatalf("got %d renderers, want 1", len(renderers))
+	}
+	if renderers[0].Name != "Kitchen Speaker" || renderers[0].URL != "http://192.0.2.42:49152/description.xml" {
+		t.Fatalf("got %#v", renderers[0])
+	}
+}

--- a/backend/playbackmanager.go
+++ b/backend/playbackmanager.go
@@ -6,12 +6,15 @@ import (
 	"fmt"
 	"log"
 	"math/rand"
+	"net"
 	"runtime"
 	"slices"
+	"strings"
 	"sync"
 	"time"
 
 	"github.com/charlievieth/strcase"
+	"github.com/koron/go-ssdp"
 	"github.com/supersonic-app/go-upnpcast/device"
 	"github.com/supersonic-app/go-upnpcast/services"
 	"github.com/supersonic-app/supersonic/backend/mediaprovider"
@@ -39,6 +42,7 @@ type PlaybackManager struct {
 
 	localPlayer         player.BasePlayer
 	remotePlayersLock   sync.Mutex
+	remoteScanLock      sync.Mutex
 	remotePlayers       []RemotePlaybackDevice
 	currentRemotePlayer *RemotePlaybackDevice
 
@@ -59,6 +63,10 @@ type PlaybackManager struct {
 	radioIcyTitle    string
 	radioIcyArtist   string
 }
+
+// go-ssdp stores the selected interfaces in package-global state. Serialize
+// every discovery that changes or reads that state, including settings scans.
+var ssdpDiscoveryLock sync.Mutex
 
 type RemotePlaybackDevice struct {
 	Name     string
@@ -251,9 +259,16 @@ func (p *PlaybackManager) ScanRemotePlayers(ctx context.Context, fastScan bool) 
 }
 
 func (p *PlaybackManager) scanRemotePlayers(ctx context.Context, waitSec int) {
-	devices, _ := device.SearchMediaRenderers(ctx, waitSec, services.AVTransport, services.RenderingControl)
+	p.remoteScanLock.Lock()
+	defer p.remoteScanLock.Unlock()
+
+	devices := searchMediaRenderers(ctx, waitSec, p.appCfg)
+	if len(devices) == 0 {
+		devices = discoverConfiguredRemotePlayers(ctx, p.appCfg.DLNARendererURLs)
+	}
 
 	coverArtPathFn := p.CoverArtPathFn
+	proxyIP := configuredDLNAProxyIP(p.appCfg)
 	var discovered []RemotePlaybackDevice
 	for _, d := range devices {
 		rp := RemotePlaybackDevice{
@@ -261,7 +276,7 @@ func (p *PlaybackManager) scanRemotePlayers(ctx context.Context, waitSec int) {
 			URL:      d.URL,
 			Protocol: "DLNA",
 			new: func() (player.BasePlayer, error) {
-				return dlna.NewDLNAPlayer(d, coverArtPathFn)
+				return dlna.NewDLNAPlayerWithLocalIP(d, coverArtPathFn, proxyIP)
 			},
 		}
 		discovered = append(discovered, rp)
@@ -270,6 +285,87 @@ func (p *PlaybackManager) scanRemotePlayers(ctx context.Context, waitSec int) {
 	p.remotePlayersLock.Lock()
 	p.remotePlayers = discovered
 	p.remotePlayersLock.Unlock()
+}
+
+func configuredDLNAProxyIP(appCfg *AppConfig) string {
+	if runtime.GOOS != "linux" || appCfg.UseDefaultSSDPInterface || appCfg.SSDPInterfaceName == "" {
+		return ""
+	}
+
+	iface, err := net.InterfaceByName(appCfg.SSDPInterfaceName)
+	if err != nil {
+		return ""
+	}
+	addresses, err := iface.Addrs()
+	if err != nil {
+		return ""
+	}
+	for _, address := range addresses {
+		ip, _, err := net.ParseCIDR(address.String())
+		if err == nil && ip.To4() != nil {
+			return ip.String()
+		}
+	}
+	return ""
+}
+
+func discoverConfiguredRemotePlayers(ctx context.Context, configured string) []*device.MediaRenderer {
+	if configured == "" {
+		return nil
+	}
+
+	var devices []*device.MediaRenderer
+	for _, rawURL := range strings.Split(configured, ",") {
+		rawURL = strings.TrimSpace(rawURL)
+		if rawURL == "" {
+			continue
+		}
+		renderer, err := device.MediaRendererFromDeviceURL(ctx, rawURL)
+		if err != nil {
+			log.Printf("DLNA: failed to load configured renderer %s: %v", rawURL, err)
+			continue
+		}
+		log.Printf("DLNA: using configured renderer %s (%s)", renderer.FriendlyName, renderer.URL)
+		devices = append(devices, renderer)
+	}
+	return devices
+}
+
+// configureSSDPInterface optionally limits Linux SSDP discovery to the
+// interface selected in Advanced settings. The default keeps go-ssdp's
+// original all-interface behavior.
+func configureSSDPInterface(appCfg *AppConfig) {
+	if runtime.GOOS != "linux" {
+		return
+	}
+
+	if appCfg.UseDefaultSSDPInterface {
+		// Leave go-ssdp's original all-interface behavior unchanged.
+		ssdp.Interfaces = nil
+		return
+	}
+
+	name := appCfg.SSDPInterfaceName
+	if name == "" {
+		log.Printf("SSDP: no interface selected; using default discovery behavior")
+		return
+	}
+	iface, err := net.InterfaceByName(name)
+	if err != nil {
+		log.Printf("SSDP: failed to use interface %q: %v", name, err)
+		return
+	}
+	ssdp.Interfaces = []net.Interface{*iface}
+	log.Printf("SSDP: using interface %s", iface.Name)
+}
+
+func searchMediaRenderers(ctx context.Context, waitSec int, appCfg *AppConfig) []*device.MediaRenderer {
+	ssdpDiscoveryLock.Lock()
+	defer ssdpDiscoveryLock.Unlock()
+
+	configureSSDPInterface(appCfg)
+	devices, _ := device.SearchMediaRenderers(ctx, waitSec, services.AVTransport, services.RenderingControl)
+	return devices
 }
 
 func (p *PlaybackManager) RemotePlayers() []RemotePlaybackDevice {

--- a/backend/playbackmanager_test.go
+++ b/backend/playbackmanager_test.go
@@ -1,0 +1,62 @@
+package backend
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestDiscoverConfiguredRemotePlayers(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/description.xml" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "text/xml")
+		fmt.Fprint(w, `<?xml version="1.0"?>
+<root xmlns="urn:schemas-upnp-org:device-1-0"><device><deviceType>urn:schemas-upnp-org:device:MediaRenderer:1</deviceType><friendlyName>Test Renderer</friendlyName><modelName>Test Model</modelName><serviceList><service><serviceType>urn:schemas-upnp-org:service:AVTransport:1</serviceType><controlURL>upnp/control/transport</controlURL><eventSubURL>upnp/event/transport</eventSubURL></service><service><serviceType>urn:schemas-upnp-org:service:RenderingControl:1</serviceType><controlURL>/upnp/control/render</controlURL></service></serviceList></device></root>`)
+	}))
+	defer server.Close()
+
+	players := discoverConfiguredRemotePlayers(context.Background(), " , "+server.URL+"/description.xml,invalid://")
+	if len(players) != 1 {
+		t.Fatalf("got %d players, want 1", len(players))
+	}
+	if players[0].FriendlyName != "Test Renderer" {
+		t.Fatalf("got renderer %q", players[0].FriendlyName)
+	}
+}
+
+func TestDiscoverConfiguredRemotePlayersEmpty(t *testing.T) {
+	if players := discoverConfiguredRemotePlayers(context.Background(), " "); players != nil {
+		t.Fatalf("got %#v, want nil", players)
+	}
+}
+
+func TestConfiguredDLNAProxyIPDefaultAndMissing(t *testing.T) {
+	if got := configuredDLNAProxyIP(&AppConfig{UseDefaultSSDPInterface: true}); got != "" {
+		t.Fatalf("default mode returned %q", got)
+	}
+	if got := configuredDLNAProxyIP(&AppConfig{SSDPInterfaceName: "does-not-exist"}); got != "" {
+		t.Fatalf("missing interface returned %q", got)
+	}
+}
+
+func TestReadConfigFileDefaultsLegacySSDPSettings(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.toml")
+	if err := os.WriteFile(path, []byte("[Application]\nMaxImageCacheSizeMB = 50\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	config, err := ReadConfigFile(path, "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !config.Application.UseDefaultSSDPInterface {
+		t.Fatal("legacy config did not preserve default SSDP behavior")
+	}
+}

--- a/backend/player/dlna/dlnaplayer.go
+++ b/backend/player/dlna/dlnaplayer.go
@@ -70,6 +70,7 @@ type DLNAPlayer struct {
 	proxyServer *http.Server
 	proxyActive atomic.Bool
 	localIP     string
+	localIPHint string
 	proxyPort   int
 
 	pendingSeek     bool
@@ -96,6 +97,16 @@ type DLNAPlayer struct {
 }
 
 func NewDLNAPlayer(device *device.MediaRenderer, coverArtPathFn func(coverArtID string) (string, error)) (*DLNAPlayer, error) {
+	return newDLNAPlayer(device, coverArtPathFn, "")
+}
+
+// NewDLNAPlayerWithLocalIP uses a caller-selected LAN address for the local
+// media proxy when the host has multiple active interfaces.
+func NewDLNAPlayerWithLocalIP(device *device.MediaRenderer, coverArtPathFn func(coverArtID string) (string, error), localIP string) (*DLNAPlayer, error) {
+	return newDLNAPlayer(device, coverArtPathFn, localIP)
+}
+
+func newDLNAPlayer(device *device.MediaRenderer, coverArtPathFn func(coverArtID string) (string, error), localIP string) (*DLNAPlayer, error) {
 	retry := retryablehttp.NewClient()
 	retry.RetryMax = 3
 	retry.RetryWaitMin = 100 * time.Millisecond
@@ -125,6 +136,7 @@ func NewDLNAPlayer(device *device.MediaRenderer, coverArtPathFn func(coverArtID 
 		renderControl:  rc,
 		resetChan:      make(chan time.Duration),
 		coverArtPathFn: coverArtPathFn,
+		localIPHint:    localIP,
 	}, nil
 }
 
@@ -475,9 +487,13 @@ func (d *DLNAPlayer) ensureSetupProxy() error {
 	}
 
 	var err error
-	d.localIP, err = util.GetLocalIP()
-	if err != nil {
-		return err
+	if d.localIPHint != "" {
+		d.localIP = d.localIPHint
+	} else {
+		d.localIP, err = util.GetLocalIP()
+		if err != nil {
+			return err
+		}
 	}
 
 	listener, err := net.Listen("tcp", ":0")
@@ -485,6 +501,7 @@ func (d *DLNAPlayer) ensureSetupProxy() error {
 		return err
 	}
 	d.proxyPort = listener.Addr().(*net.TCPAddr).Port
+	log.Printf("DLNA: serving local media proxy at %s:%d", d.localIP, d.proxyPort)
 
 	d.proxyServer = &http.Server{
 		Handler: http.HandlerFunc(d.handleRequest),

--- a/backend/player/dlna/dlnaplayer_test.go
+++ b/backend/player/dlna/dlnaplayer_test.go
@@ -1,0 +1,39 @@
+package dlna
+
+import (
+	"testing"
+	"time"
+
+	"github.com/supersonic-app/supersonic/backend/mediaprovider"
+)
+
+func TestBuildMediaItemCopiesAudioMetadata(t *testing.T) {
+	player := &DLNAPlayer{}
+	meta := mediaprovider.MediaItemMetadata{
+		MIMEType:     "audio/mpeg",
+		Name:         "Track",
+		Artists:      []string{"Artist One", "Artist Two"},
+		Album:        "Album",
+		TrackNumber:  3,
+		Duration:     2*time.Minute + 3*time.Second,
+		Size:         1234,
+		BitRate:      192,
+		SampleRate:   44100,
+		BitDepth:     16,
+		ChannelCount: 2,
+	}
+
+	item := player.buildMediaItem("http://192.0.2.10:40000/track", meta)
+	if item.URL != "http://192.0.2.10:40000/track" || item.Title != "Track" {
+		t.Fatalf("unexpected item identity: %#v", item)
+	}
+	if item.Artist != "Artist One, Artist Two" || item.Album != "Album" || item.TrackNumber != 3 {
+		t.Fatalf("unexpected item metadata: %#v", item)
+	}
+	if item.Duration != meta.Duration || item.Size != meta.Size || item.Bitrate != 192*125 {
+		t.Fatalf("unexpected item stream metadata: %#v", item)
+	}
+	if item.SampleFrequency != 44100 || item.BitsPerSample != 16 || item.NrAudioChannels != 2 {
+		t.Fatalf("unexpected audio metadata: %#v", item)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/supersonic-app/supersonic
 
+replace github.com/supersonic-app/go-upnpcast => ./third_party/go-upnpcast
+
 go 1.24.0
 
 require (

--- a/third_party/go-upnpcast/LICENSE
+++ b/third_party/go-upnpcast/LICENSE
@@ -1,0 +1,22 @@
+MIT License
+
+Copyright (c) 2021 Alexandros Ballas
+Copyright (c) 2025 Drew Weymouth, Jacob Alzén, and contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/third_party/go-upnpcast/README.md
+++ b/third_party/go-upnpcast/README.md
@@ -1,0 +1,10 @@
+[![Go API Reference](https://img.shields.io/badge/go-documentation-blue.svg?style=flat)](https://pkg.go.dev/github.com/supersonic-app/go-upnpcast)
+# go-upnpcast
+
+**Status**: In development. This library is functional but not API stable.
+
+Go library for casting media to uPnP/DLNA devices.
+
+This code originates as an extraction and refactoring of the uPnP/DLNA backend of [Go2TV](https://github.com/alexballas/go2tv) by Alex Ballas.
+
+See the example in the `cmd` directory.

--- a/third_party/go-upnpcast/cmd/main.go
+++ b/third_party/go-upnpcast/cmd/main.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/supersonic-app/go-upnpcast/device"
+	"github.com/supersonic-app/go-upnpcast/services/avtransport"
+)
+
+func main() {
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM)
+
+	var devices []*device.MediaRenderer
+	var err error
+	if devices, err = device.SearchMediaRenderers(context.Background(), 5); err != nil {
+		log.Printf("Error loading devices: %v", err)
+	}
+
+	if len(devices) == 0 {
+		log.Printf("No devices")
+		return
+	}
+	dev := devices[0]
+	cli, err := dev.AVTransportClient()
+	if err != nil {
+		panic(err)
+	}
+	err = cli.SetAVTransportMedia(context.Background(), &avtransport.MediaItem{
+		URL:   `https://file-examples.com/storage/fe6a71582967c9a269c25cd/2017/11/file_example_MP3_700KB.mp3`,
+		Title: "Foo",
+	})
+	cli.Play(context.Background())
+
+	err = cli.SetNextAVTransportMedia(context.Background(), &avtransport.MediaItem{
+		URL:   `https://download.samplelib.com/mp3/sample-15s.mp3`,
+		Title: "Example mp3",
+	})
+	if err != nil {
+		log.Println(err.Error())
+	}
+	log.Println("Playing two files")
+
+	go func() {
+		<-sigChan
+		cli.Stop(context.Background())
+		os.Exit(0)
+	}()
+
+	pos, _ := cli.GetPositionInfo(context.Background())
+	log.Printf("%+v", pos)
+
+	time.Sleep(3 * time.Second)
+
+	cli.Seek(context.Background(), 35)
+	pos, _ = cli.GetPositionInfo(context.Background())
+	log.Printf("%+v", pos)
+}

--- a/third_party/go-upnpcast/device/device.go
+++ b/third_party/go-upnpcast/device/device.go
@@ -1,0 +1,122 @@
+package device
+
+import (
+	"cmp"
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+
+	"github.com/koron/go-ssdp"
+	"github.com/supersonic-app/go-upnpcast/services"
+	"github.com/supersonic-app/go-upnpcast/services/avtransport"
+	"github.com/supersonic-app/go-upnpcast/services/renderingcontrol"
+)
+
+var ErrUnsupportedService = errors.New("the device does not support the requested service")
+
+// MediaRenderer represents a Digital Media Renderer (DMR) device discovered on the LAN
+type MediaRenderer struct {
+	// URL for the device's service descrption manifest
+	URL string
+
+	// Friendly name of the device
+	FriendlyName string
+
+	// Model name of the device
+	ModelName string
+
+	avTransportControlURL  string
+	avTransportEventSubURL string
+	renderingControlURL    string
+	connectionManagerURL   string
+}
+
+// SearchMediaRenderers searches for MediaRenderer devices on the LAN
+// that implement all the service types specified in `requiredServices`
+// - waitSec is how many seconds to wait for device responses to the SSDP search
+// If passing a context with deadline/expiration, it should be longer than waitSec
+func SearchMediaRenderers(ctx context.Context, waitSec int, requiredServices ...services.Type) ([]*MediaRenderer, error) {
+	deviceLocations, err := getSSDPAVTransportDeviceLocations(waitSec)
+	if err != nil {
+		return nil, err
+	}
+
+	devices := make([]*MediaRenderer, 0, len(deviceLocations))
+	errors := []error{}
+	for _, l := range deviceLocations {
+		mr, err := mediaRendererFromDeviceURL(ctx, l)
+		if err != nil {
+			errors = append(errors, err)
+			continue
+		}
+		for _, required := range requiredServices {
+			if !mr.SupportsService(required) {
+				errors = append(errors, fmt.Errorf("%s does not support %s", mr.FriendlyName, required))
+				mr = nil
+				break
+			}
+		}
+		if mr == nil {
+			continue
+		}
+		devices = append(devices, mr)
+	}
+
+	return devices, cmp.Or(errors...)
+}
+
+// SupportsService returns true if the MediaRenderer supports the given service type
+func (m *MediaRenderer) SupportsService(serviceType services.Type) bool {
+	switch serviceType {
+	case services.AVTransport:
+		return m.avTransportControlURL != "" && m.avTransportEventSubURL != ""
+	case services.ConnectionManager:
+		return m.connectionManagerURL != ""
+	case services.RenderingControl:
+		return m.renderingControlURL != ""
+	}
+	return false
+}
+
+// AVTransportClient returns a new client to the device's AVTransport service.
+func (m *MediaRenderer) AVTransportClient() (*avtransport.Client, error) {
+	if !m.SupportsService(services.AVTransport) {
+		return nil, ErrUnsupportedService
+	}
+	return avtransport.NewClient(m.avTransportControlURL, m.avTransportEventSubURL), nil
+}
+
+// RenderingControlClient returns a new client to the device's RenderingControl service.
+func (m *MediaRenderer) RenderingControlClient() (*renderingcontrol.Client, error) {
+	if !m.SupportsService(services.RenderingControl) {
+		return nil, ErrUnsupportedService
+	}
+	return renderingcontrol.NewClient(m.renderingControlURL), nil
+}
+
+// Gets the list of DMR schema URLs for all found devices that support the AVTransport service
+func getSSDPAVTransportDeviceLocations(waitSec int) ([]string, error) {
+	ssdpServices, err := ssdp.Search(ssdp.All, waitSec, "")
+	if err != nil {
+		return nil, fmt.Errorf("SSDP search error: %w", err)
+	}
+
+	var deviceLocations listSet
+	for _, srv := range ssdpServices {
+		// All DMRs we care about must support the AVTransport service
+		if srv.Type == services.AVTransport {
+			deviceLocations.add(srv.Location)
+		}
+	}
+	return deviceLocations, nil
+}
+
+type listSet []string
+
+func (l *listSet) add(s string) {
+	if slices.Contains(*l, s) {
+		return
+	}
+	*l = append(*l, s)
+}

--- a/third_party/go-upnpcast/device/unmarshal.go
+++ b/third_party/go-upnpcast/device/unmarshal.go
@@ -1,0 +1,141 @@
+package device
+
+import (
+	"context"
+	"encoding/xml"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/supersonic-app/go-upnpcast/services"
+)
+
+type device struct {
+	DeviceType   string `xml:"deviceType"`
+	FriendlyName string `xml:"friendlyName"`
+	ModelName    string `xml:"modelName"`
+
+	ServiceList struct {
+		Services []struct {
+			Type        services.Type `xml:"serviceType"`
+			ID          string        `xml:"serviceId"`
+			ControlURL  string        `xml:"controlURL"`
+			EventSubURL string        `xml:"eventSubURL"`
+		} `xml:"service"`
+	} `xml:"serviceList"`
+
+	DeviceList struct {
+		Devices []device `xml:"device"`
+	} `xml:"deviceList"`
+}
+
+type dmrSchema struct {
+	XMLName xml.Name `xml:"root"`
+	Device  device   `xml:"device"`
+}
+
+func mediaRendererFromDeviceURL(ctx context.Context, dmrurl string) (*MediaRenderer, error) {
+	parsedURL, err := url.Parse(dmrurl)
+	if err != nil || parsedURL.Scheme == "" || parsedURL.Host == "" {
+		return nil, fmt.Errorf("device URL parse error: %w", err)
+	}
+
+	client := &http.Client{}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, dmrurl, nil)
+	if err != nil {
+		return nil, fmt.Errorf("setup GET device manifest error: %w", err)
+	}
+	req.Header.Set("Connection", "close")
+
+	xmlresp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("do GET device manifest error: %w", err)
+	}
+	defer xmlresp.Body.Close()
+	if xmlresp.StatusCode < http.StatusOK || xmlresp.StatusCode >= http.StatusMultipleChoices {
+		return nil, fmt.Errorf("device manifest HTTP status: %s", xmlresp.Status)
+	}
+
+	var root dmrSchema
+	err = xml.NewDecoder(xmlresp.Body).Decode(&root)
+	if err != nil {
+		return nil, fmt.Errorf("unmarshal device manifest error: %w", err)
+	}
+
+	mrDevice := findMediaRenderer(root.Device)
+	if mrDevice == nil {
+		return nil, errors.New("no MediaRenderer device found")
+	}
+
+	mr := &MediaRenderer{
+		URL:          dmrurl,
+		FriendlyName: mrDevice.FriendlyName,
+		ModelName:    mrDevice.ModelName,
+	}
+	for i := 0; i < len(mrDevice.ServiceList.Services); i++ {
+		service := mrDevice.ServiceList.Services[i]
+
+		switch service.Type {
+		case services.AVTransport:
+			mr.avTransportControlURL, err = resolveServiceURL(parsedURL, service.ControlURL)
+			if err != nil {
+				return nil, fmt.Errorf("invalid AVTransportControlURL: %w", err)
+			}
+			mr.avTransportEventSubURL, err = resolveServiceURL(parsedURL, service.EventSubURL)
+			if err != nil {
+				return nil, fmt.Errorf("invalid AVTransportEventSubURL: %w", err)
+			}
+		case services.RenderingControl:
+			mr.renderingControlURL, err = resolveServiceURL(parsedURL, service.ControlURL)
+			if err != nil {
+				return nil, fmt.Errorf("invalid RenderingControlURL: %w", err)
+			}
+		case services.ConnectionManager:
+			mr.connectionManagerURL, err = resolveServiceURL(parsedURL, service.ControlURL)
+			if err != nil {
+				return nil, fmt.Errorf("invalid ConnectionManagerURL: %w", err)
+			}
+		}
+	}
+
+	if mr.avTransportControlURL != "" {
+		return mr, nil
+	}
+
+	return nil, errors.New("wrong DMR")
+}
+
+func resolveServiceURL(base *url.URL, raw string) (string, error) {
+	ref, err := url.Parse(raw)
+	if err != nil {
+		return "", err
+	}
+	resolved := base.ResolveReference(ref)
+	if resolved.Scheme == "" || resolved.Host == "" {
+		return "", errors.New("service URL has no scheme or host")
+	}
+	return resolved.String(), nil
+}
+
+// MediaRendererFromDeviceURL creates a renderer from a known device
+// description URL. This is useful for devices that expose UPnP correctly but
+// do not answer SSDP M-SEARCH requests.
+func MediaRendererFromDeviceURL(ctx context.Context, dmrurl string) (*MediaRenderer, error) {
+	return mediaRendererFromDeviceURL(ctx, dmrurl)
+}
+
+func findMediaRenderer(d device) *device {
+	// MediaRenderer can be either at root or nested
+	if d.DeviceType == "urn:schemas-upnp-org:device:MediaRenderer:1" {
+		return &d
+	}
+
+	for i := range d.DeviceList.Devices {
+		if mr := findMediaRenderer(d.DeviceList.Devices[i]); mr != nil {
+			return mr
+		}
+	}
+
+	return nil
+}

--- a/third_party/go-upnpcast/device/unmarshal_test.go
+++ b/third_party/go-upnpcast/device/unmarshal_test.go
@@ -1,0 +1,48 @@
+package device
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+const testRendererDescription = `<?xml version="1.0"?>
+<root xmlns="urn:schemas-upnp-org:device-1-0"><device>
+<deviceType>urn:schemas-upnp-org:device:MediaRenderer:1</deviceType>
+<friendlyName>Renderer</friendlyName><modelName>Model</modelName>
+<serviceList>
+<service><serviceType>urn:schemas-upnp-org:service:AVTransport:1</serviceType><controlURL>control/transport</controlURL><eventSubURL>event/transport</eventSubURL></service>
+<service><serviceType>urn:schemas-upnp-org:service:RenderingControl:1</serviceType><controlURL>/control/render</controlURL></service>
+</serviceList></device></root>`
+
+func TestMediaRendererFromDeviceURLResolvesServiceURLs(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, testRendererDescription)
+	}))
+	defer server.Close()
+
+	renderer, err := mediaRendererFromDeviceURL(context.Background(), server.URL+"/upnp/description.xml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	client, err := renderer.AVTransportClient()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if client == nil || renderer.renderingControlURL != server.URL+"/control/render" {
+		t.Fatalf("service URLs were not resolved correctly: %#v", renderer)
+	}
+}
+
+func TestMediaRendererFromDeviceURLRejectsHTTPError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "unavailable", http.StatusServiceUnavailable)
+	}))
+	defer server.Close()
+
+	if _, err := mediaRendererFromDeviceURL(context.Background(), server.URL+"/description.xml"); err == nil {
+		t.Fatal("expected HTTP error")
+	}
+}

--- a/third_party/go-upnpcast/go.mod
+++ b/third_party/go-upnpcast/go.mod
@@ -1,0 +1,13 @@
+module github.com/supersonic-app/go-upnpcast
+
+go 1.24.0
+
+require (
+	github.com/h2non/filetype v1.1.3
+	github.com/koron/go-ssdp v0.1.0
+)
+
+require (
+	golang.org/x/net v0.44.0 // indirect
+	golang.org/x/sys v0.36.0 // indirect
+)

--- a/third_party/go-upnpcast/go.sum
+++ b/third_party/go-upnpcast/go.sum
@@ -1,0 +1,8 @@
+github.com/h2non/filetype v1.1.3 h1:FKkx9QbD7HR/zjK1Ia5XiBsq9zdLi5Kf3zGyFTAFkGg=
+github.com/h2non/filetype v1.1.3/go.mod h1:319b3zT68BvV+WRj7cwy856M2ehB3HqNOt6sy1HndBY=
+github.com/koron/go-ssdp v0.1.0 h1:ckl5x5H6qSNFmi+wCuROvvGUu2FQnMbQrU95IHCcv3Y=
+github.com/koron/go-ssdp v0.1.0/go.mod h1:GltaDBjtK1kemZOusWYLGotV0kBeEf59Bp0wtSB0uyU=
+golang.org/x/net v0.44.0 h1:evd8IRDyfNBMBTTY5XRF1vaZlD+EmWx6x8PkhR04H/I=
+golang.org/x/net v0.44.0/go.mod h1:ECOoLqd5U3Lhyeyo/QDCEVQ4sNgYsqvCZ722XogGieY=
+golang.org/x/sys v0.36.0 h1:KVRy2GtZBrk1cBYA7MKu5bEZFxQk4NIDV6RLVcC8o0k=
+golang.org/x/sys v0.36.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=

--- a/third_party/go-upnpcast/internal/utils/dlnautils.go
+++ b/third_party/go-upnpcast/internal/utils/dlnautils.go
@@ -1,0 +1,207 @@
+package utils
+
+import (
+	"bytes"
+	"encoding/xml"
+	"errors"
+	"fmt"
+	"io"
+	"math"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/h2non/filetype"
+)
+
+const XMLStart = `<?xml version="1.0" encoding="utf-8"?>`
+
+const (
+	// dlnaOrgFlagSenderPaced = 1 << 31
+	// dlnaOrgFlagTimeBasedSeek = 1 << 30
+	// dlnaOrgFlagByteBasedSeek = 1 << 29
+	// dlnaOrgFlagPlayContainer = 1 << 28
+	// dlnaOrgFlagS0Increase = 1 << 27
+	// dlnaOrgFlagSnIncrease = 1 << 26
+	// dlnaOrgFlagRtspPause = 1 << 25
+	dlnaOrgFlagStreamingTransferMode = 1 << 24
+	// dlnaOrgFlagInteractiveTransfertMode = 1 << 23
+	dlnaOrgFlagBackgroundTransfertMode = 1 << 22
+	dlnaOrgFlagConnectionStall         = 1 << 21
+	dlnaOrgFlagDlnaV15                 = 1 << 20
+)
+
+var (
+	dlnaprofiles = map[string]string{
+		"video/x-mkv":             "DLNA.ORG_PN=MATROSKA",
+		"video/x-matroska":        "DLNA.ORG_PN=MATROSKA",
+		"video/x-msvideo":         "DLNA.ORG_PN=AVI",
+		"video/mpeg":              "DLNA.ORG_PN=MPEG1",
+		"video/vnd.dlna.mpeg-tts": "DLNA.ORG_PN=MPEG1",
+		"video/mp4":               "DLNA.ORG_PN=AVC_MP4_MP_SD_AAC_MULT5",
+		"video/quicktime":         "DLNA.ORG_PN=AVC_MP4_MP_SD_AAC_MULT5",
+		"video/x-m4v":             "DLNA.ORG_PN=AVC_MP4_MP_SD_AAC_MULT5",
+		"video/3gpp":              "DLNA.ORG_PN=AVC_MP4_MP_SD_AAC_MULT5",
+		"video/x-flv":             "DLNA.ORG_PN=AVC_MP4_MP_SD_AAC_MULT5",
+		"video/x-ms-wmv":          "DLNA.ORG_PN=WMVHIGH_FULL",
+		"audio/mpeg":              "DLNA.ORG_PN=MP3",
+		"image/jpeg":              "JPEG_LRG",
+		"image/png":               "PNG_LRG",
+	}
+
+	ErrInvalidSeekFlag    = errors.New("invalid seek flag")
+	ErrInvalidClockFormat = errors.New("invalid clock format")
+)
+
+func defaultStreamingFlags() string {
+	return fmt.Sprintf("%.8x%.24x", dlnaOrgFlagStreamingTransferMode|
+		dlnaOrgFlagBackgroundTransfertMode|
+		dlnaOrgFlagConnectionStall|
+		dlnaOrgFlagDlnaV15, 0)
+}
+
+func BuildRequestHeader(soapAction string) http.Header {
+	return http.Header{
+		"SOAPAction":   []string{soapAction},
+		"content-type": []string{"text/xml"},
+		"charset":      []string{"utf-8"},
+		"Connection":   []string{"close"},
+	}
+}
+
+// BuildContentFeatures builds the content features string
+// for the "contentFeatures.dlna.org" header.
+func BuildContentFeatures(mediaType string, seek string, transcode bool) (string, error) {
+	var cf strings.Builder
+
+	if mediaType != "" {
+		dlnaProf, profExists := dlnaprofiles[mediaType]
+		if profExists {
+			cf.WriteString(dlnaProf + ";")
+		}
+	}
+
+	// "00" neither time seek range nor range supported
+	// "01" range supported
+	// "10" time seek range supported
+	// "11" both time seek range and range supported
+	switch seek {
+	case "00":
+		cf.WriteString("DLNA.ORG_OP=00;")
+	case "01":
+		cf.WriteString("DLNA.ORG_OP=01;")
+	case "10":
+		cf.WriteString("DLNA.ORG_OP=10;")
+	case "11":
+		cf.WriteString("DLNA.ORG_OP=11;")
+	default:
+		return "", ErrInvalidSeekFlag
+	}
+
+	switch transcode {
+	case true:
+		cf.WriteString("DLNA.ORG_CI=1;")
+	default:
+		cf.WriteString("DLNA.ORG_CI=0;")
+	}
+
+	cf.WriteString("DLNA.ORG_FLAGS=")
+	cf.WriteString(defaultStreamingFlags())
+
+	return cf.String(), nil
+}
+
+// GetMimeDetails returns the media mime details.
+func GetMimeDetails(f io.ReadCloser) (string, error) {
+	defer f.Close()
+	head := make([]byte, 261)
+	_, err := f.Read(head)
+	if err != nil {
+		return "", fmt.Errorf("getMimeDetailsFromFile error #2: %w", err)
+	}
+
+	kind, err := filetype.Match(head)
+	if err != nil {
+		return "", fmt.Errorf("getMimeDetailsFromFile error #3: %w", err)
+	}
+
+	return fmt.Sprintf("%s/%s", kind.MIME.Type, kind.MIME.Subtype), nil
+}
+
+// ClockTimeToSeconds converts relative time to seconds.
+func ClockTimeToSeconds(strtime string) (int, error) {
+	s := strings.Split(strtime, ":")
+	if len(s) != 3 {
+		return 0, ErrInvalidClockFormat
+	}
+
+	hours, err := strconv.Atoi(s[0])
+	if err != nil {
+		return 0, ErrInvalidClockFormat
+	}
+
+	minutes, err := strconv.Atoi(s[1])
+	if err != nil {
+		return 0, ErrInvalidClockFormat
+	}
+
+	f, err := strconv.ParseFloat(s[2], 32)
+	if err != nil {
+		return 0, ErrInvalidClockFormat
+	}
+	seconds := int(math.Round(f))
+
+	return hours*3600 + minutes*60 + seconds, nil
+}
+
+// SecondsToClockTime converts seconds to seconds relative time.
+func SecondsToClockTime(secs int) string {
+	hours := secs / 3600
+	secs %= 3600
+	minutes := secs / 60
+	secs %= 60
+
+	return fmt.Sprintf("%02d:%02d:%02d", hours, minutes, secs)
+}
+
+// FormatClockTime converts clock time to a more expected format of clock time.
+func FormatClockTime(strtime string) (string, error) {
+	sec, err := ClockTimeToSeconds(strtime)
+	if err != nil {
+		return "", ErrInvalidClockFormat
+	}
+
+	return SecondsToClockTime(sec), nil
+}
+
+// ParseDuration parses a HH:MM:SS or MM:SS formatted string
+// into a [time.Duration] value.
+func ParseDuration(durStr string) (time.Duration, error) {
+	timeformat := ""
+	switch strings.Count(durStr, ":") {
+	case 2:
+		timeformat = "04:05"
+	case 3:
+		timeformat = "15:04:05"
+	default:
+		return 0, fmt.Errorf("invalid format: expected MM:SS or HH:MM:SS")
+	}
+
+	t, err := time.Parse(timeformat, durStr)
+	if err != nil {
+		return 0, ErrInvalidClockFormat
+	}
+
+	midnight := time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, t.Location())
+	return t.Sub(midnight), nil
+}
+
+func MarshalXMLWithStart(d any) (io.Reader, error) {
+	b, err := xml.Marshal(d)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling error: %w", err)
+	}
+
+	return io.MultiReader(strings.NewReader(XMLStart), bytes.NewReader(b)), nil
+}

--- a/third_party/go-upnpcast/services/avtransport/avtransport.go
+++ b/third_party/go-upnpcast/services/avtransport/avtransport.go
@@ -1,0 +1,273 @@
+package avtransport
+
+import (
+	"cmp"
+	"context"
+	"encoding/json"
+	"encoding/xml"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/supersonic-app/go-upnpcast/internal/utils"
+	"github.com/supersonic-app/go-upnpcast/services"
+)
+
+type Client struct {
+	RequestHandler services.RequestHandler
+	controlURL     string
+}
+
+// MediaItem represents a media item to be rendered by the device.
+type MediaItem struct {
+	// URL of the media item. Required.
+	URL string
+
+	SubtitlesURL string
+	Title        string
+	ContentType  string
+	Seekable     bool
+	Duration     time.Duration
+
+	// Audio / music metadata. Emitted into DIDL-Lite when non-zero.
+	// Renderers use these to populate their displays (cover art, artist,
+	// album, sample-rate / bit-depth readouts) and as hints about the
+	// underlying stream.
+	Artist          string
+	Album           string
+	AlbumArtURI     string
+	TrackNumber     int
+	Size            int64
+	Bitrate         int // bytes/sec, per DIDL-Lite res@bitrate
+	SampleFrequency int // Hz
+	BitsPerSample   int
+	NrAudioChannels int
+}
+
+// TransportInfo is the information returned by GetTransportInfo
+type TransportInfo struct {
+	Status string
+	State  string
+	Speed  string
+}
+
+// PositionInfo is the duration and current playback position of the current media item,
+// returned by GetPositionInfo
+type PositionInfo struct {
+	Duration time.Duration
+	RelTime  time.Duration
+}
+
+// Should not be used directly. Use device.AVTransportClient() instead.
+func NewClient(controlURL, eventSubURL string) *Client {
+	return &Client{
+		RequestHandler: &http.Client{Timeout: 10 * time.Second},
+		controlURL:     controlURL,
+	}
+}
+
+func (a *Client) Play(ctx context.Context) error {
+	return a.playPauseStopSoapCall(ctx, "Play")
+}
+
+func (a *Client) Pause(ctx context.Context) error {
+	return a.playPauseStopSoapCall(ctx, "Pause")
+}
+
+func (a *Client) Stop(ctx context.Context) error {
+	return a.playPauseStopSoapCall(ctx, "Stop")
+}
+
+func (a *Client) Seek(ctx context.Context, relSecs int) error {
+	time := utils.SecondsToClockTime(relSecs)
+	xml, err := seekSoapBuild(time)
+	if err != nil {
+		return fmt.Errorf("SeekSoapCall action error: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "POST", a.controlURL, xml)
+	if err != nil {
+		return fmt.Errorf("SeekSoapCall POST error: %w", err)
+	}
+	req.Header = utils.BuildRequestHeader(`"urn:schemas-upnp-org:service:AVTransport:1#Seek"`)
+
+	res, err := a.RequestHandler.Do(req)
+	if err != nil {
+		return fmt.Errorf("SeekSoapCall Do POST error: %w", err)
+	}
+	defer res.Body.Close()
+
+	_, err = io.ReadAll(res.Body)
+	if err != nil {
+		return fmt.Errorf("SeekSoapCall Failed to read response: %w", err)
+	}
+
+	_, err = json.Marshal(res.Header)
+	if err != nil {
+		return fmt.Errorf("SeekSoapCall Response Marshaling error: %w", err)
+	}
+
+	return nil
+
+}
+
+func (a *Client) SetAVTransportMedia(ctx context.Context, media *MediaItem) error {
+	soapCall, err := setAVTransportSoapBuild(media)
+	if err != nil {
+		return fmt.Errorf("SetAVTransportMedia build error: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, "POST", a.controlURL, soapCall)
+	if err != nil {
+		return fmt.Errorf("SetAVTransportMedia POST error: %w", err)
+	}
+	req.Header = utils.BuildRequestHeader(`"urn:schemas-upnp-org:service:AVTransport:1#SetAVTransportURI"`)
+	res, err := a.RequestHandler.Do(req)
+	if err != nil {
+		return fmt.Errorf("SetAVTransportMedia Do POST error: %w", err)
+	}
+	defer res.Body.Close()
+	if res.StatusCode < 200 || res.StatusCode >= 300 {
+		body, _ := io.ReadAll(res.Body)
+		return fmt.Errorf("SetAVTransportMedia HTTP %s: %s", res.Status, string(body))
+	}
+
+	var resp setAVTransportURIResponse
+	if err := xml.NewDecoder(res.Body).Decode(&resp); err != nil {
+		return fmt.Errorf("SetAVTransportMedia Failed to unmarshal response: %w", err)
+	}
+
+	return nil
+}
+
+func (a *Client) SetNextAVTransportMedia(ctx context.Context, media *MediaItem) error {
+	soapCall, err := setNextAVTransportSoapBuild(media)
+	if err != nil {
+		return fmt.Errorf("SetNextAVTransportMedia build error: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, "POST", a.controlURL, soapCall)
+	if err != nil {
+		return fmt.Errorf("SetNextAVTransportMedia POST error: %w", err)
+	}
+
+	req.Header = utils.BuildRequestHeader(`"urn:schemas-upnp-org:service:AVTransport:1#SetNextAVTransportURI"`)
+	res, err := a.RequestHandler.Do(req)
+	if err != nil {
+		return fmt.Errorf("SetNextAVTransportMedia Do POST error: %w", err)
+	}
+	defer res.Body.Close()
+
+	var resp setNextAVTransportURIResponse
+	if err := xml.NewDecoder(res.Body).Decode(&resp); err != nil {
+		return fmt.Errorf("SetNextAVTransportMedia Failed to unmarshal response: %w", err)
+	}
+
+	return nil
+}
+
+// GetTransportInfo
+func (a *Client) GetTransportInfo(ctx context.Context) (TransportInfo, error) {
+	xmlbuilder, err := getTransportInfoSoapBuild()
+	if err != nil {
+		return TransportInfo{}, fmt.Errorf("GetTransportInfo build error: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "POST", a.controlURL, xmlbuilder)
+	if err != nil {
+		return TransportInfo{}, fmt.Errorf("GetTransportInfo POST error: %w", err)
+	}
+	req.Header = utils.BuildRequestHeader(`"urn:schemas-upnp-org:service:AVTransport:1#GetTransportInfo"`)
+
+	res, err := a.RequestHandler.Do(req)
+	if err != nil {
+		return TransportInfo{}, fmt.Errorf("GetTransportInfo Do POST error: %w", err)
+	}
+	defer res.Body.Close()
+
+	var respTransportInfo getTransportInfoResponse
+	if err := xml.NewDecoder(res.Body).Decode(&respTransportInfo); err != nil {
+		return TransportInfo{}, fmt.Errorf("GetTransportInfo Failed to unmarshal response: %w", err)
+	}
+
+	r := respTransportInfo.Body.GetTransportInfoResponse
+	return TransportInfo{
+		Status: r.CurrentTransportStatus,
+		State:  r.CurrentTransportState,
+		Speed:  r.CurrentSpeed,
+	}, nil
+}
+
+func (a *Client) GetPositionInfo(ctx context.Context) (PositionInfo, error) {
+	xmlRequest, err := getPositionInfoSoapBuild()
+	if err != nil {
+		return PositionInfo{}, fmt.Errorf("GetPositionInfo build error: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "POST", a.controlURL, xmlRequest)
+	if err != nil {
+		return PositionInfo{}, fmt.Errorf("GetPositionInfo POST error: %w", err)
+	}
+	req.Header = utils.BuildRequestHeader(`"urn:schemas-upnp-org:service:AVTransport:1#GetPositionInfo"`)
+
+	res, err := a.RequestHandler.Do(req)
+	if err != nil {
+		return PositionInfo{}, fmt.Errorf("GetPositionInfo Do POST error: %w", err)
+	}
+	defer res.Body.Close()
+
+	var respPositionInfo getPositionInfoResponse
+	if err := xml.NewDecoder(res.Body).Decode(&respPositionInfo); err != nil {
+		return PositionInfo{}, fmt.Errorf("GetPositionInfo Failed to unmarshal response: %w", err)
+	}
+
+	r := respPositionInfo.Body.GetPositionInfoResponse
+	dur, err := utils.ParseDuration(r.TrackDuration)
+	rel, err2 := utils.ParseDuration(r.RelTime)
+	return PositionInfo{Duration: dur, RelTime: rel}, cmp.Or(err, err2)
+}
+
+func (a *Client) playPauseStopSoapCall(ctx context.Context, action string) error {
+	var data io.Reader
+	var err error
+
+	switch action {
+	case "Play":
+		data, err = playSoapBuild()
+	case "Stop":
+		data, err = stopSoapBuild()
+	case "Pause":
+		data, err = pauseSoapBuild()
+	}
+	if err != nil {
+		return fmt.Errorf("AVTransportActionSoapCall action error: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "POST", a.controlURL, data)
+	if err != nil {
+		return fmt.Errorf("AVTransportActionSoapCall POST error: %w", err)
+	}
+
+	req.Header = utils.BuildRequestHeader(`"urn:schemas-upnp-org:service:AVTransport:1#` + action + `"`)
+
+	res, err := a.RequestHandler.Do(req)
+	if err != nil {
+		return fmt.Errorf("AVTransportActionSoapCall Do POST error: %w", err)
+	}
+	defer res.Body.Close()
+	if res.StatusCode < 200 || res.StatusCode >= 300 {
+		body, _ := io.ReadAll(res.Body)
+		return fmt.Errorf("AVTransportActionSoapCall HTTP %s: %s", res.Status, string(body))
+	}
+
+	_, err = io.ReadAll(res.Body)
+	if err != nil {
+		return fmt.Errorf("AVTransportActionSoapCall Failed to read response: %w", err)
+	}
+
+	_, err = json.Marshal(res.Header)
+	if err != nil {
+		return fmt.Errorf("AVTransportActionSoapCall Response Marshaling error: %w", err)
+	}
+
+	return nil
+}

--- a/third_party/go-upnpcast/services/avtransport/requestbuilders.go
+++ b/third_party/go-upnpcast/services/avtransport/requestbuilders.go
@@ -1,0 +1,537 @@
+package avtransport
+
+import (
+	"bytes"
+	"encoding/xml"
+	"fmt"
+	"io"
+	"math"
+	"strings"
+
+	"github.com/supersonic-app/go-upnpcast/internal/utils"
+)
+
+type playEnvelope struct {
+	XMLName  xml.Name `xml:"s:Envelope"`
+	Schema   string   `xml:"xmlns:s,attr"`
+	Encoding string   `xml:"s:encodingStyle,attr"`
+	PlayBody playBody `xml:"s:Body"`
+}
+
+type playBody struct {
+	XMLName    xml.Name   `xml:"s:Body"`
+	PlayAction playAction `xml:"u:Play"`
+}
+
+type playAction struct {
+	XMLName     xml.Name `xml:"u:Play"`
+	AVTransport string   `xml:"xmlns:u,attr"`
+	InstanceID  string
+	Speed       string
+}
+
+type pauseEnvelope struct {
+	XMLName   xml.Name  `xml:"s:Envelope"`
+	Schema    string    `xml:"xmlns:s,attr"`
+	Encoding  string    `xml:"s:encodingStyle,attr"`
+	PauseBody pauseBody `xml:"s:Body"`
+}
+
+type pauseBody struct {
+	XMLName     xml.Name    `xml:"s:Body"`
+	PauseAction pauseAction `xml:"u:Pause"`
+}
+
+type pauseAction struct {
+	XMLName     xml.Name `xml:"u:Pause"`
+	AVTransport string   `xml:"xmlns:u,attr"`
+	InstanceID  string
+	Speed       string
+}
+
+type stopEnvelope struct {
+	XMLName  xml.Name `xml:"s:Envelope"`
+	Schema   string   `xml:"xmlns:s,attr"`
+	Encoding string   `xml:"s:encodingStyle,attr"`
+	StopBody stopBody `xml:"s:Body"`
+}
+
+type stopBody struct {
+	XMLName    xml.Name   `xml:"s:Body"`
+	StopAction stopAction `xml:"u:Stop"`
+}
+
+type stopAction struct {
+	XMLName     xml.Name `xml:"u:Stop"`
+	AVTransport string   `xml:"xmlns:u,attr"`
+	InstanceID  string
+	Speed       string
+}
+
+type seekEnvelope struct {
+	XMLName  xml.Name `xml:"s:Envelope"`
+	Schema   string   `xml:"xmlns:s,attr"`
+	Encoding string   `xml:"s:encodingStyle,attr"`
+	SeekBody seekBody `xml:"s:Body"`
+}
+
+type seekBody struct {
+	XMLName    xml.Name   `xml:"s:Body"`
+	SeekAction seekAction `xml:"u:Seek"`
+}
+
+type seekAction struct {
+	XMLName     xml.Name `xml:"u:Seek"`
+	AVTransport string   `xml:"xmlns:u,attr"`
+	InstanceID  string
+	Unit        string
+	Target      string
+}
+
+type setAVTransportEnvelope struct {
+	XMLName  xml.Name           `xml:"s:Envelope"`
+	Schema   string             `xml:"xmlns:s,attr"`
+	Encoding string             `xml:"s:encodingStyle,attr"`
+	Body     setAVTransportBody `xml:"s:Body"`
+}
+
+type setAVTransportBody struct {
+	XMLName           xml.Name          `xml:"s:Body"`
+	SetAVTransportURI setAVTransportURI `xml:"u:SetAVTransportURI"`
+}
+
+type setAVTransportURI struct {
+	XMLName            xml.Name `xml:"u:SetAVTransportURI"`
+	AVTransport        string   `xml:"xmlns:u,attr"`
+	InstanceID         string
+	CurrentURI         string
+	CurrentURIMetaData currentURIMetaData `xml:"CurrentURIMetaData"`
+}
+
+type currentURIMetaData struct {
+	XMLName xml.Name `xml:"CurrentURIMetaData"`
+	Value   []byte   `xml:",chardata"`
+}
+
+type setNextAVTransportEnvelope struct {
+	XMLName  xml.Name               `xml:"s:Envelope"`
+	Schema   string                 `xml:"xmlns:s,attr"`
+	Encoding string                 `xml:"s:encodingStyle,attr"`
+	Body     setNextAVTransportBody `xml:"s:Body"`
+}
+
+type setNextAVTransportBody struct {
+	XMLName               xml.Name              `xml:"s:Body"`
+	SetNextAVTransportURI setNextAVTransportURI `xml:"u:SetNextAVTransportURI"`
+}
+
+type setNextAVTransportURI struct {
+	XMLName         xml.Name `xml:"u:SetNextAVTransportURI"`
+	AVTransport     string   `xml:"xmlns:u,attr"`
+	InstanceID      string
+	NextURI         string
+	NextURIMetaData nextURIMetaData `xml:"NextURIMetaData"`
+}
+
+type nextURIMetaData struct {
+	XMLName xml.Name `xml:"NextURIMetaData"`
+	Value   []byte   `xml:",chardata"`
+}
+
+type didLLite struct {
+	XMLName      xml.Name     `xml:"DIDL-Lite"`
+	SchemaDIDL   string       `xml:"xmlns,attr"`
+	DC           string       `xml:"xmlns:dc,attr"`
+	Sec          string       `xml:"xmlns:sec,attr"`
+	SchemaUPNP   string       `xml:"xmlns:upnp,attr"`
+	DIDLLiteItem didLLiteItem `xml:"item"`
+}
+
+type didLLiteItem struct {
+	SecCaptionInfo       *secCaptionInfo   `xml:"sec:CaptionInfo,omitempty"`
+	SecCaptionInfoEx     *secCaptionInfoEx `xml:"sec:CaptionInfoEx,omitempty"`
+	XMLName              xml.Name          `xml:"item"`
+	DCtitle              string            `xml:"dc:title"`
+	DCcreator            string            `xml:"dc:creator,omitempty"`
+	UPNPartist           string            `xml:"upnp:artist,omitempty"`
+	UPNPalbum            string            `xml:"upnp:album,omitempty"`
+	UPNPoriginalTrackNum int               `xml:"upnp:originalTrackNumber,omitempty"`
+	UPNPalbumArtURI      string            `xml:"upnp:albumArtURI,omitempty"`
+	UPNPClass            string            `xml:"upnp:class"`
+	ID                   string            `xml:"id,attr"`
+	ParentID             string            `xml:"parentID,attr"`
+	Restricted           string            `xml:"restricted,attr"`
+	ResNode              []resNode         `xml:"res"`
+}
+
+type resNode struct {
+	XMLName         xml.Name `xml:"res"`
+	Duration        string   `xml:"duration,attr,omitempty"`
+	Size            int64    `xml:"size,attr,omitempty"`
+	Bitrate         int      `xml:"bitrate,attr,omitempty"`
+	SampleFrequency int      `xml:"sampleFrequency,attr,omitempty"`
+	BitsPerSample   int      `xml:"bitsPerSample,attr,omitempty"`
+	NrAudioChannels int      `xml:"nrAudioChannels,attr,omitempty"`
+	ProtocolInfo    string   `xml:"protocolInfo,attr"`
+	Value           string   `xml:",chardata"`
+}
+
+type secCaptionInfo struct {
+	XMLName xml.Name `xml:"sec:CaptionInfo"`
+	Type    string   `xml:"sec:type,attr"`
+	Value   string   `xml:",chardata"`
+}
+
+type secCaptionInfoEx struct {
+	XMLName xml.Name `xml:"sec:CaptionInfoEx"`
+	Type    string   `xml:"sec:type,attr"`
+	Value   string   `xml:",chardata"`
+}
+
+type getMediaInfoEnvelope struct {
+	XMLName          xml.Name         `xml:"s:Envelope"`
+	Schema           string           `xml:"xmlns:s,attr"`
+	Encoding         string           `xml:"s:encodingStyle,attr"`
+	GetMediaInfoBody getMediaInfoBody `xml:"s:Body"`
+}
+
+type getMediaInfoBody struct {
+	XMLName            xml.Name           `xml:"s:Body"`
+	GetMediaInfoAction getMediaInfoAction `xml:"u:GetMediaInfo"`
+}
+
+type getMediaInfoAction struct {
+	XMLName     xml.Name `xml:"u:GetMediaInfo"`
+	AVTransport string   `xml:"xmlns:u,attr"`
+	InstanceID  string
+}
+
+type getTransportInfoEnvelope struct {
+	XMLName              xml.Name             `xml:"s:Envelope"`
+	Schema               string               `xml:"xmlns:s,attr"`
+	Encoding             string               `xml:"s:encodingStyle,attr"`
+	GetTransportInfoBody getTransportInfoBody `xml:"s:Body"`
+}
+
+type getTransportInfoBody struct {
+	XMLName                xml.Name               `xml:"s:Body"`
+	GetTransportInfoAction getTransportInfoAction `xml:"u:GetTransportInfo"`
+}
+
+type getTransportInfoAction struct {
+	XMLName     xml.Name `xml:"u:GetTransportInfo"`
+	AVTransport string   `xml:"xmlns:u,attr"`
+	InstanceID  string
+}
+
+type getPositionInfoEnvelope struct {
+	XMLName             xml.Name            `xml:"s:Envelope"`
+	Schema              string              `xml:"xmlns:s,attr"`
+	Encoding            string              `xml:"s:encodingStyle,attr"`
+	GetPositionInfoBody getPositionInfoBody `xml:"s:Body"`
+}
+
+type getPositionInfoBody struct {
+	XMLName               xml.Name              `xml:"s:Body"`
+	GetPositionInfoAction getPositionInfoAction `xml:"u:GetPositionInfo"`
+}
+
+type getPositionInfoAction struct {
+	XMLName     xml.Name `xml:"u:GetPositionInfo"`
+	AVTransport string   `xml:"xmlns:u,attr"`
+	InstanceID  string
+}
+
+func buildURIMetadataPayload(media *MediaItem) ([]byte, error) {
+	mediaTypeSlice := strings.Split(media.ContentType, "/")
+	seekflag := "00"
+	if media.Seekable {
+		seekflag = "01"
+	}
+
+	contentFeatures, err := utils.BuildContentFeatures(media.ContentType, seekflag, false /*transcode*/)
+	if err != nil {
+		return nil, fmt.Errorf("buildURIMetadataPayload failed to build contentFeatures: %w", err)
+	}
+
+	var class string
+	switch mediaTypeSlice[0] {
+	case "audio":
+		class = "object.item.audioItem.musicTrack"
+	case "image":
+		class = "object.item.imageItem.photo"
+	default:
+		class = "object.item.videoItem.movie"
+	}
+
+	var didl didLLiteItem
+
+	primary := resNode{
+		XMLName:         xml.Name{},
+		Size:            media.Size,
+		Bitrate:         media.Bitrate,
+		SampleFrequency: media.SampleFrequency,
+		BitsPerSample:   media.BitsPerSample,
+		NrAudioChannels: media.NrAudioChannels,
+		ProtocolInfo:    fmt.Sprintf("http-get:*:%s:%s", media.ContentType, contentFeatures),
+		Value:           media.URL,
+	}
+	if media.Duration > 0 {
+		primary.Duration = utils.SecondsToClockTime(int(math.Round(media.Duration.Seconds())))
+	}
+	resNodeData := []resNode{primary}
+
+	// Pre-escape free-text fields so that the Samsung TV un-escape pass below
+	// leaves them XML-safe (xml.Marshal escapes them once, then the un-escape
+	// removes one layer, netting a single layer of escaping).
+	escape := func(s string) string {
+		var buf bytes.Buffer
+		if err := xml.EscapeText(&buf, []byte(s)); err != nil {
+			return ""
+		}
+		return buf.String()
+	}
+	didl = didLLiteItem{
+		XMLName:              xml.Name{},
+		ID:                   "1",
+		ParentID:             "0",
+		Restricted:           "1",
+		UPNPClass:            class,
+		DCtitle:              escape(media.Title),
+		DCcreator:            escape(media.Artist),
+		UPNPartist:           escape(media.Artist),
+		UPNPalbum:            escape(media.Album),
+		UPNPoriginalTrackNum: media.TrackNumber,
+		UPNPalbumArtURI:      escape(media.AlbumArtURI),
+		ResNode:              resNodeData,
+	}
+
+	if strings.Contains(media.SubtitlesURL, "srt") {
+		resNodeData = append(resNodeData, resNode{
+			XMLName:      xml.Name{},
+			ProtocolInfo: "http-get:*:text/srt:*",
+			Value:        media.SubtitlesURL,
+		})
+		didl.ResNode = resNodeData
+		didl.SecCaptionInfo = &secCaptionInfo{
+			XMLName: xml.Name{},
+			Type:    "srt",
+			Value:   media.SubtitlesURL,
+		}
+		didl.SecCaptionInfoEx = &secCaptionInfoEx{
+			XMLName: xml.Name{},
+			Type:    "srt",
+			Value:   media.SubtitlesURL,
+		}
+	}
+
+	l := didLLite{
+		XMLName:      xml.Name{},
+		SchemaDIDL:   "urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/",
+		DC:           "http://purl.org/dc/elements/1.1/",
+		Sec:          "http://www.sec.co.kr/",
+		SchemaUPNP:   "urn:schemas-upnp-org:metadata-1-0/upnp/",
+		DIDLLiteItem: didl,
+	}
+
+	a, err := xml.Marshal(l)
+	if err != nil {
+		return nil, fmt.Errorf("buildURIMetadataPayload #1 Marshal error: %w", err)
+	}
+	return a, nil
+}
+
+func setAVTransportSoapBuild(media *MediaItem) (io.Reader, error) {
+	meta, err := buildURIMetadataPayload(media)
+	if err != nil {
+		return nil, err
+	}
+	d := setAVTransportEnvelope{
+		XMLName:  xml.Name{},
+		Schema:   "http://schemas.xmlsoap.org/soap/envelope/",
+		Encoding: "http://schemas.xmlsoap.org/soap/encoding/",
+		Body: setAVTransportBody{
+			XMLName: xml.Name{},
+			SetAVTransportURI: setAVTransportURI{
+				XMLName:     xml.Name{},
+				AVTransport: "urn:schemas-upnp-org:service:AVTransport:1",
+				InstanceID:  "0",
+				CurrentURI:  media.URL,
+				CurrentURIMetaData: currentURIMetaData{
+					XMLName: xml.Name{},
+					Value:   meta,
+				},
+			},
+		},
+	}
+	b, err := xml.Marshal(d)
+	if err != nil {
+		return nil, fmt.Errorf("setAVTransportSoapBuild #2 Marshal error: %w", err)
+	}
+
+	// Samsung TV hack.
+	b = bytes.ReplaceAll(b, []byte("&#34;"), []byte(`"`))
+	b = bytes.ReplaceAll(b, []byte("&amp;"), []byte("&"))
+
+	return io.MultiReader(strings.NewReader(utils.XMLStart), bytes.NewReader(b)), nil
+}
+
+func setNextAVTransportSoapBuild(media *MediaItem) (io.Reader, error) {
+	meta, err := buildURIMetadataPayload(media)
+	if err != nil {
+		return nil, err
+	}
+
+	d := setNextAVTransportEnvelope{
+		XMLName:  xml.Name{},
+		Schema:   "http://schemas.xmlsoap.org/soap/envelope/",
+		Encoding: "http://schemas.xmlsoap.org/soap/encoding/",
+		Body: setNextAVTransportBody{
+			XMLName: xml.Name{},
+			SetNextAVTransportURI: setNextAVTransportURI{
+				XMLName:     xml.Name{},
+				AVTransport: "urn:schemas-upnp-org:service:AVTransport:1",
+				InstanceID:  "0",
+				NextURI:     media.URL,
+				NextURIMetaData: nextURIMetaData{
+					XMLName: xml.Name{},
+					Value:   meta,
+				},
+			},
+		},
+	}
+	b, err := xml.Marshal(d)
+	if err != nil {
+		return nil, fmt.Errorf("setNextAVTransportSoapBuild #2 Marshal error: %w", err)
+	}
+
+	// Samsung TV hack.
+	b = bytes.ReplaceAll(b, []byte("&#34;"), []byte(`"`))
+	b = bytes.ReplaceAll(b, []byte("&amp;"), []byte("&"))
+
+	return io.MultiReader(strings.NewReader(utils.XMLStart), bytes.NewReader(b)), nil
+}
+
+func playSoapBuild() (io.Reader, error) {
+	d := playEnvelope{
+		XMLName:  xml.Name{},
+		Schema:   "http://schemas.xmlsoap.org/soap/envelope/",
+		Encoding: "http://schemas.xmlsoap.org/soap/encoding/",
+		PlayBody: playBody{
+			XMLName: xml.Name{},
+			PlayAction: playAction{
+				XMLName:     xml.Name{},
+				AVTransport: "urn:schemas-upnp-org:service:AVTransport:1",
+				InstanceID:  "0",
+				Speed:       "1",
+			},
+		},
+	}
+	return utils.MarshalXMLWithStart(d)
+}
+
+func stopSoapBuild() (io.Reader, error) {
+	d := stopEnvelope{
+		XMLName:  xml.Name{},
+		Schema:   "http://schemas.xmlsoap.org/soap/envelope/",
+		Encoding: "http://schemas.xmlsoap.org/soap/encoding/",
+		StopBody: stopBody{
+			XMLName: xml.Name{},
+			StopAction: stopAction{
+				XMLName:     xml.Name{},
+				AVTransport: "urn:schemas-upnp-org:service:AVTransport:1",
+				InstanceID:  "0",
+				Speed:       "1",
+			},
+		},
+	}
+	return utils.MarshalXMLWithStart(d)
+}
+
+func pauseSoapBuild() (io.Reader, error) {
+	d := pauseEnvelope{
+		XMLName:  xml.Name{},
+		Schema:   "http://schemas.xmlsoap.org/soap/envelope/",
+		Encoding: "http://schemas.xmlsoap.org/soap/encoding/",
+		PauseBody: pauseBody{
+			XMLName: xml.Name{},
+			PauseAction: pauseAction{
+				XMLName:     xml.Name{},
+				AVTransport: "urn:schemas-upnp-org:service:AVTransport:1",
+				InstanceID:  "0",
+				Speed:       "1",
+			},
+		},
+	}
+	return utils.MarshalXMLWithStart(d)
+}
+
+func getMediaInfoSoapBuild() (io.Reader, error) {
+	d := getMediaInfoEnvelope{
+		XMLName:  xml.Name{},
+		Schema:   "http://schemas.xmlsoap.org/soap/envelope/",
+		Encoding: "http://schemas.xmlsoap.org/soap/encoding/",
+		GetMediaInfoBody: getMediaInfoBody{
+			XMLName: xml.Name{},
+			GetMediaInfoAction: getMediaInfoAction{
+				XMLName:     xml.Name{},
+				AVTransport: "urn:schemas-upnp-org:service:AVTransport:1",
+				InstanceID:  "0",
+			},
+		},
+	}
+	return utils.MarshalXMLWithStart(d)
+}
+
+func getTransportInfoSoapBuild() (io.Reader, error) {
+	d := getTransportInfoEnvelope{
+		XMLName:  xml.Name{},
+		Schema:   "http://schemas.xmlsoap.org/soap/envelope/",
+		Encoding: "http://schemas.xmlsoap.org/soap/encoding/",
+		GetTransportInfoBody: getTransportInfoBody{
+			XMLName: xml.Name{},
+			GetTransportInfoAction: getTransportInfoAction{
+				XMLName:     xml.Name{},
+				AVTransport: "urn:schemas-upnp-org:service:AVTransport:1",
+				InstanceID:  "0",
+			},
+		},
+	}
+	return utils.MarshalXMLWithStart(d)
+}
+
+func getPositionInfoSoapBuild() (io.Reader, error) {
+	d := getPositionInfoEnvelope{
+		XMLName:  xml.Name{},
+		Schema:   "http://schemas.xmlsoap.org/soap/envelope/",
+		Encoding: "http://schemas.xmlsoap.org/soap/encoding/",
+		GetPositionInfoBody: getPositionInfoBody{
+			XMLName: xml.Name{},
+			GetPositionInfoAction: getPositionInfoAction{
+				XMLName:     xml.Name{},
+				AVTransport: "urn:schemas-upnp-org:service:AVTransport:1",
+				InstanceID:  "0",
+			},
+		},
+	}
+	return utils.MarshalXMLWithStart(d)
+}
+
+func seekSoapBuild(reltime string) (io.Reader, error) {
+	d := seekEnvelope{
+		XMLName:  xml.Name{},
+		Schema:   "http://schemas.xmlsoap.org/soap/envelope/",
+		Encoding: "http://schemas.xmlsoap.org/soap/encoding/",
+		SeekBody: seekBody{
+			XMLName: xml.Name{},
+			SeekAction: seekAction{
+				XMLName:     xml.Name{},
+				AVTransport: "urn:schemas-upnp-org:service:AVTransport:1",
+				InstanceID:  "0",
+				Unit:        "REL_TIME",
+				Target:      reltime,
+			},
+		},
+	}
+	return utils.MarshalXMLWithStart(d)
+}

--- a/third_party/go-upnpcast/services/avtransport/requestbuilders_test.go
+++ b/third_party/go-upnpcast/services/avtransport/requestbuilders_test.go
@@ -1,0 +1,308 @@
+package avtransport
+
+import (
+	"io"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/supersonic-app/go-upnpcast/internal/utils"
+)
+
+func TestSetAVTransportSoapBuild(t *testing.T) {
+	tt := []struct {
+		name  string
+		media *MediaItem
+	}{
+		{
+			`setAVTransportSoapBuild Test #1`,
+			&MediaItem{
+				Title:        "foo",
+				URL:          `http://192.168.88.250:3500/video%20%26%20%27example%27.mp4`,
+				ContentType:  "video/mp4",
+				SubtitlesURL: "http://192.168.88.250:3500/video_example.srt",
+				//Transcode:    false,
+				Seekable: true,
+			},
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			seekflag := "00"
+			if tc.media.Seekable {
+				seekflag = "01"
+			}
+
+			contentFeatures, err := utils.BuildContentFeatures(tc.media.ContentType, seekflag, false /*transcode - TODO*/)
+			if err != nil {
+				t.Fatalf("%s: setAVTransportSoapBuild failed to build contentFeatures: %s", tc.name, err.Error())
+			}
+
+			want := `<?xml version="1.0" encoding="utf-8"?><s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"><s:Body><u:SetAVTransportURI xmlns:u="urn:schemas-upnp-org:service:AVTransport:1"><InstanceID>0</InstanceID><CurrentURI>http://192.168.88.250:3500/video%20%26%20%27example%27.mp4</CurrentURI><CurrentURIMetaData>&lt;DIDL-Lite xmlns="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:sec="http://www.sec.co.kr/" xmlns:upnp="urn:schemas-upnp-org:metadata-1-0/upnp/"&gt;&lt;item id="1" parentID="0" restricted="1"&gt;&lt;sec:CaptionInfo sec:type="srt"&gt;http://192.168.88.250:3500/video_example.srt&lt;/sec:CaptionInfo&gt;&lt;sec:CaptionInfoEx sec:type="srt"&gt;http://192.168.88.250:3500/video_example.srt&lt;/sec:CaptionInfoEx&gt;&lt;dc:title&gt;foo&lt;/dc:title&gt;&lt;upnp:class&gt;object.item.videoItem.movie&lt;/upnp:class&gt;&lt;res protocolInfo="http-get:*:video/mp4:` + contentFeatures + `"&gt;http://192.168.88.250:3500/video%20%26%20%27example%27.mp4&lt;/res&gt;&lt;res protocolInfo="http-get:*:text/srt:*"&gt;http://192.168.88.250:3500/video_example.srt&lt;/res&gt;&lt;/item&gt;&lt;/DIDL-Lite&gt;</CurrentURIMetaData></u:SetAVTransportURI></s:Body></s:Envelope>`
+
+			out, err := setAVTransportSoapBuild(tc.media)
+			if err != nil {
+				t.Fatalf("%s: Failed to call setAVTransportSoapBuild due to %s", tc.name, err.Error())
+			}
+			if readerToString(out) != want {
+				t.Fatalf("%s: got: %s, want: %s.", tc.name, out, want)
+			}
+		})
+	}
+}
+
+func TestSetNextAVTransportSoapBuild(t *testing.T) {
+	tt := []struct {
+		name string
+		tv   *MediaItem
+	}{
+		{
+			`setNextAVTransportSoapBuild Test #1`,
+			&MediaItem{
+				Title:        "foo",
+				URL:          `http://192.168.88.250:3500/video%20%26%20%27example%27.mp4`,
+				ContentType:  "video/mp4",
+				SubtitlesURL: "http://192.168.88.250:3500/video_example.srt",
+				//Transcode:    false,
+				Seekable: true,
+			},
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			seekflag := "00"
+			if tc.tv.Seekable {
+				seekflag = "01"
+			}
+
+			contentFeatures, err := utils.BuildContentFeatures(tc.tv.ContentType, seekflag, false /*transcode*/)
+			if err != nil {
+				t.Fatalf("%s: setNextAVTransportSoapBuild failed to build contentFeatures: %s", tc.name, err.Error())
+			}
+
+			want := `<?xml version="1.0" encoding="utf-8"?><s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"><s:Body><u:SetNextAVTransportURI xmlns:u="urn:schemas-upnp-org:service:AVTransport:1"><InstanceID>0</InstanceID><NextURI>http://192.168.88.250:3500/video%20%26%20%27example%27.mp4</NextURI><NextURIMetaData>&lt;DIDL-Lite xmlns="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:sec="http://www.sec.co.kr/" xmlns:upnp="urn:schemas-upnp-org:metadata-1-0/upnp/"&gt;&lt;item id="1" parentID="0" restricted="1"&gt;&lt;sec:CaptionInfo sec:type="srt"&gt;http://192.168.88.250:3500/video_example.srt&lt;/sec:CaptionInfo&gt;&lt;sec:CaptionInfoEx sec:type="srt"&gt;http://192.168.88.250:3500/video_example.srt&lt;/sec:CaptionInfoEx&gt;&lt;dc:title&gt;foo&lt;/dc:title&gt;&lt;upnp:class&gt;object.item.videoItem.movie&lt;/upnp:class&gt;&lt;res protocolInfo="http-get:*:video/mp4:` + contentFeatures + `"&gt;http://192.168.88.250:3500/video%20%26%20%27example%27.mp4&lt;/res&gt;&lt;res protocolInfo="http-get:*:text/srt:*"&gt;http://192.168.88.250:3500/video_example.srt&lt;/res&gt;&lt;/item&gt;&lt;/DIDL-Lite&gt;</NextURIMetaData></u:SetNextAVTransportURI></s:Body></s:Envelope>`
+
+			out, err := setNextAVTransportSoapBuild(tc.tv)
+			if err != nil {
+				t.Fatalf("%s: Failed to call setNextAVTransportSoapBuild due to %s", tc.name, err.Error())
+			}
+			if readerToString(out) != want {
+				t.Fatalf("%s: got: %s, want: %s.", tc.name, out, want)
+			}
+		})
+	}
+}
+
+func TestPlaySoapBuild(t *testing.T) {
+	tt := []struct {
+		name string
+		want string
+	}{
+		{
+			`playSoapBuild Test #1`,
+			`<?xml version="1.0" encoding="utf-8"?><s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"><s:Body><u:Play xmlns:u="urn:schemas-upnp-org:service:AVTransport:1"><InstanceID>0</InstanceID><Speed>1</Speed></u:Play></s:Body></s:Envelope>`,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			out, err := playSoapBuild()
+			if err != nil {
+				t.Fatalf("%s: Failed to call playSoapBuild due to %s", tc.name, err.Error())
+			}
+			if readerToString(out) != tc.want {
+				t.Fatalf("%s: got: %s, want: %s.", tc.name, out, tc.want)
+			}
+		})
+	}
+}
+
+func TestStopSoapBuild(t *testing.T) {
+	tt := []struct {
+		name string
+		want string
+	}{
+		{
+			`stopSoapBuild Test #1`,
+			`<?xml version="1.0" encoding="utf-8"?><s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"><s:Body><u:Stop xmlns:u="urn:schemas-upnp-org:service:AVTransport:1"><InstanceID>0</InstanceID><Speed>1</Speed></u:Stop></s:Body></s:Envelope>`,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			out, err := stopSoapBuild()
+			if err != nil {
+				t.Fatalf("%s: Failed to call stopSoapBuild due to %s", tc.name, err.Error())
+			}
+			if readerToString(out) != tc.want {
+				t.Fatalf("%s: got: %s, want: %s.", tc.name, out, tc.want)
+			}
+		})
+	}
+}
+
+func TestPauseSoapBuild(t *testing.T) {
+	tt := []struct {
+		name string
+		want string
+	}{
+		{
+			`pauseSoapBuild Test #1`,
+			`<?xml version="1.0" encoding="utf-8"?><s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"><s:Body><u:Pause xmlns:u="urn:schemas-upnp-org:service:AVTransport:1"><InstanceID>0</InstanceID><Speed>1</Speed></u:Pause></s:Body></s:Envelope>`,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			out, err := pauseSoapBuild()
+			if err != nil {
+				t.Fatalf("%s: Failed to call pauseSoapBuild due to %s", tc.name, err.Error())
+			}
+			if readerToString(out) != tc.want {
+				t.Fatalf("%s: got: %s, want: %s.", tc.name, out, tc.want)
+			}
+		})
+	}
+}
+
+func TestGetTransportInfoSoapBuild(t *testing.T) {
+	tt := []struct {
+		name string
+		want string
+	}{
+		{
+			`getTransportInfoSoapBuildTest #1`,
+			`<?xml version="1.0" encoding="utf-8"?><s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"><s:Body><u:GetTransportInfo xmlns:u="urn:schemas-upnp-org:service:AVTransport:1"><InstanceID>0</InstanceID></u:GetTransportInfo></s:Body></s:Envelope>`,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			out, err := getTransportInfoSoapBuild()
+			if err != nil {
+				t.Fatalf("%s: Failed to call getTransportInfoSoapBuild due to %s", tc.name, err.Error())
+			}
+			if readerToString(out) != tc.want {
+				t.Fatalf("%s: got: %s, want: %s.", tc.name, out, tc.want)
+			}
+		})
+	}
+}
+
+func TestGetPositionInfoSoapBuild(t *testing.T) {
+	tt := []struct {
+		name string
+		want string
+	}{
+		{
+			`getPositionInfoSoapBuildTest #1`,
+			`<?xml version="1.0" encoding="utf-8"?><s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"><s:Body><u:GetPositionInfo xmlns:u="urn:schemas-upnp-org:service:AVTransport:1"><InstanceID>0</InstanceID></u:GetPositionInfo></s:Body></s:Envelope>`,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			out, err := getPositionInfoSoapBuild()
+			if err != nil {
+				t.Fatalf("%s: Failed to call getPositionInfoSoapBuild due to %s", tc.name, err.Error())
+			}
+			if readerToString(out) != tc.want {
+				t.Fatalf("%s: got: %s, want: %s.", tc.name, out, tc.want)
+			}
+		})
+	}
+}
+
+func TestSeekSoapBuild(t *testing.T) {
+	tt := []struct {
+		name   string
+		target string
+		want   string
+	}{
+		{
+			`seekSoapBuildTest #1`,
+			"00:01:30",
+			`<?xml version="1.0" encoding="utf-8"?><s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"><s:Body><u:Seek xmlns:u="urn:schemas-upnp-org:service:AVTransport:1"><InstanceID>0</InstanceID><Unit>REL_TIME</Unit><Target>00:01:30</Target></u:Seek></s:Body></s:Envelope>`,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			out, err := seekSoapBuild(tc.target)
+			if err != nil {
+				t.Fatalf("%s: Failed to call seekSoapBuild due to %s", tc.name, err.Error())
+			}
+			if readerToString(out) != tc.want {
+				t.Fatalf("%s: got: %s, want: %s.", tc.name, out, tc.want)
+			}
+		})
+	}
+}
+
+func TestBuildURIMetadataPayload_MusicMetadata(t *testing.T) {
+	media := &MediaItem{
+		Title:           "Needed Time",
+		Artist:          "Some Artist",
+		Album:           "Some Album",
+		AlbumArtURI:     "http://192.0.2.10:56736/art",
+		TrackNumber:     7,
+		URL:             "http://192.0.2.10:56736/stream",
+		ContentType:     "audio/x-dsf",
+		Seekable:        true,
+		Duration:        313 * time.Second,
+		Size:            221457176,
+		Bitrate:         5645000,
+		SampleFrequency: 2822400,
+		BitsPerSample:   1,
+		NrAudioChannels: 2,
+	}
+
+	contentFeatures, err := utils.BuildContentFeatures(media.ContentType, "01", false)
+	if err != nil {
+		t.Fatalf("BuildContentFeatures: %v", err)
+	}
+
+	want := `<DIDL-Lite xmlns="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:sec="http://www.sec.co.kr/" xmlns:upnp="urn:schemas-upnp-org:metadata-1-0/upnp/"><item id="1" parentID="0" restricted="1"><dc:title>Needed Time</dc:title><dc:creator>Some Artist</dc:creator><upnp:artist>Some Artist</upnp:artist><upnp:album>Some Album</upnp:album><upnp:originalTrackNumber>7</upnp:originalTrackNumber><upnp:albumArtURI>http://192.0.2.10:56736/art</upnp:albumArtURI><upnp:class>object.item.audioItem.musicTrack</upnp:class><res duration="00:05:13" size="221457176" bitrate="5645000" sampleFrequency="2822400" bitsPerSample="1" nrAudioChannels="2" protocolInfo="http-get:*:audio/x-dsf:` + contentFeatures + `">http://192.0.2.10:56736/stream</res></item></DIDL-Lite>`
+
+	got, err := buildURIMetadataPayload(media)
+	if err != nil {
+		t.Fatalf("buildURIMetadataPayload: %v", err)
+	}
+	if string(got) != want {
+		t.Fatalf("\ngot:  %s\nwant: %s", got, want)
+	}
+}
+
+func TestBuildURIMetadataPayload_AudioMinimal(t *testing.T) {
+	// When only the required fields are populated, no new metadata elements
+	// or <res> audio attributes should appear (omitempty path).
+	media := &MediaItem{
+		Title:       "Just A Title",
+		URL:         "http://192.0.2.10:56736/stream",
+		ContentType: "audio/flac",
+		Seekable:    true,
+	}
+
+	contentFeatures, err := utils.BuildContentFeatures(media.ContentType, "01", false)
+	if err != nil {
+		t.Fatalf("BuildContentFeatures: %v", err)
+	}
+
+	want := `<DIDL-Lite xmlns="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:sec="http://www.sec.co.kr/" xmlns:upnp="urn:schemas-upnp-org:metadata-1-0/upnp/"><item id="1" parentID="0" restricted="1"><dc:title>Just A Title</dc:title><upnp:class>object.item.audioItem.musicTrack</upnp:class><res protocolInfo="http-get:*:audio/flac:` + contentFeatures + `">http://192.0.2.10:56736/stream</res></item></DIDL-Lite>`
+
+	got, err := buildURIMetadataPayload(media)
+	if err != nil {
+		t.Fatalf("buildURIMetadataPayload: %v", err)
+	}
+	if string(got) != want {
+		t.Fatalf("\ngot:  %s\nwant: %s", got, want)
+	}
+}
+
+func readerToString(r io.Reader) string {
+	var buf strings.Builder
+	io.Copy(&buf, r)
+	return buf.String()
+}

--- a/third_party/go-upnpcast/services/avtransport/unmarshal.go
+++ b/third_party/go-upnpcast/services/avtransport/unmarshal.go
@@ -1,0 +1,70 @@
+package avtransport
+
+import "encoding/xml"
+
+type getPositionInfoResponse struct {
+	XMLName       xml.Name `xml:"Envelope"`
+	Text          string   `xml:",chardata"`
+	S             string   `xml:"s,attr"`
+	EncodingStyle string   `xml:"encodingStyle,attr"`
+	Body          struct {
+		Text                    string `xml:",chardata"`
+		GetPositionInfoResponse struct {
+			Text          string `xml:",chardata"`
+			U             string `xml:"u,attr"`
+			Track         string `xml:"Track"`
+			TrackDuration string `xml:"TrackDuration"`
+			TrackMetaData string `xml:"TrackMetaData"`
+			TrackURI      string `xml:"TrackURI"`
+			RelTime       string `xml:"RelTime"`
+			AbsTime       string `xml:"AbsTime"`
+			RelCount      string `xml:"RelCount"`
+			AbsCount      string `xml:"AbsCount"`
+		} `xml:"GetPositionInfoResponse"`
+	} `xml:"Body"`
+}
+
+type getTransportInfoResponse struct {
+	XMLName       xml.Name `xml:"Envelope"`
+	Text          string   `xml:",chardata"`
+	S             string   `xml:"s,attr"`
+	EncodingStyle string   `xml:"encodingStyle,attr"`
+	Body          struct {
+		Text                     string `xml:",chardata"`
+		GetTransportInfoResponse struct {
+			Text                   string `xml:",chardata"`
+			U                      string `xml:"u,attr"`
+			CurrentTransportState  string `xml:"CurrentTransportState"`
+			CurrentTransportStatus string `xml:"CurrentTransportStatus"`
+			CurrentSpeed           string `xml:"CurrentSpeed"`
+		} `xml:"GetTransportInfoResponse"`
+	} `xml:"Body"`
+}
+
+type setAVTransportURIResponse struct {
+	XMLName       xml.Name `xml:"Envelope"`
+	Text          string   `xml:",chardata"`
+	S             string   `xml:"s,attr"`
+	EncodingStyle string   `xml:"encodingStyle,attr"`
+	Body          struct {
+		Text                      string `xml:",chardata"`
+		SetAVTransportURIResponse struct {
+			Text string `xml:",chardata"`
+			U    string `xml:"u,attr"`
+		} `xml:"SetAVTransportURIResponse"`
+	} `xml:"Body"`
+}
+
+type setNextAVTransportURIResponse struct {
+	XMLName       xml.Name `xml:"Envelope"`
+	Text          string   `xml:",chardata"`
+	S             string   `xml:"s,attr"`
+	EncodingStyle string   `xml:"encodingStyle,attr"`
+	Body          struct {
+		Text                      string `xml:",chardata"`
+		SetAVTransportURIResponse struct {
+			Text string `xml:",chardata"`
+			U    string `xml:"u,attr"`
+		} `xml:"SetNextAVTransportURIResponse"`
+	} `xml:"Body"`
+}

--- a/third_party/go-upnpcast/services/connectionmanager/requestbuilders.go
+++ b/third_party/go-upnpcast/services/connectionmanager/requestbuilders.go
@@ -1,0 +1,41 @@
+package connectionmanager
+
+import (
+	"encoding/xml"
+	"io"
+
+	"github.com/supersonic-app/go-upnpcast/internal/utils"
+)
+
+type getProtocolInfoEnvelope struct {
+	XMLName             xml.Name            `xml:"s:Envelope"`
+	Schema              string              `xml:"xmlns:s,attr"`
+	Encoding            string              `xml:"s:encodingStyle,attr"`
+	GetProtocolInfoBody getProtocolInfoBody `xml:"s:Body"`
+}
+
+type getProtocolInfoBody struct {
+	XMLName               xml.Name              `xml:"s:Body"`
+	GetProtocolInfoAction getProtocolInfoAction `xml:"u:GetProtocolInfo"`
+}
+
+type getProtocolInfoAction struct {
+	XMLName           xml.Name `xml:"u:GetProtocolInfo"`
+	ConnectionManager string   `xml:"xmlns:u,attr"`
+}
+
+func getProtocolInfoSoapBuild() (io.Reader, error) {
+	d := getProtocolInfoEnvelope{
+		XMLName:  xml.Name{},
+		Schema:   "http://schemas.xmlsoap.org/soap/envelope/",
+		Encoding: "http://schemas.xmlsoap.org/soap/encoding/",
+		GetProtocolInfoBody: getProtocolInfoBody{
+			XMLName: xml.Name{},
+			GetProtocolInfoAction: getProtocolInfoAction{
+				XMLName:           xml.Name{},
+				ConnectionManager: "urn:schemas-upnp-org:service:ConnectionManager:1",
+			},
+		},
+	}
+	return utils.MarshalXMLWithStart(d)
+}

--- a/third_party/go-upnpcast/services/renderingcontrol/renderingcontrol.go
+++ b/third_party/go-upnpcast/services/renderingcontrol/renderingcontrol.go
@@ -1,0 +1,144 @@
+package renderingcontrol
+
+import (
+	"context"
+	"encoding/xml"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/supersonic-app/go-upnpcast/internal/utils"
+)
+
+// Client is a client to the device's RenderingControl service
+type Client struct {
+	Requesthandler *http.Client
+	controlURL     string
+}
+
+// Should not be used directly. Use device.RenderingControlClient() instead.
+func NewClient(controlURL string) *Client {
+	return &Client{
+		Requesthandler: &http.Client{Timeout: 10 * time.Second},
+		controlURL:     controlURL,
+	}
+}
+
+// GetMute returns the mute status for our device
+func (c *Client) GetMute(ctx context.Context) (string, error) {
+	xmlbuilder, err := getMuteSoapBuild()
+	if err != nil {
+		return "", fmt.Errorf("GetMuteSoapCall build error: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "POST", c.controlURL, xmlbuilder)
+	if err != nil {
+		return "", fmt.Errorf("GetMuteSoapCall POST error: %w", err)
+	}
+
+	req.Header = http.Header{
+		"SOAPAction":   []string{`"urn:schemas-upnp-org:service:RenderingControl:1#GetMute"`},
+		"content-type": []string{"text/xml"},
+		"charset":      []string{"utf-8"},
+		"Connection":   []string{"close"},
+	}
+
+	res, err := c.Requesthandler.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("GetMuteSoapCall Do POST error: %w", err)
+	}
+	defer res.Body.Close()
+
+	var respGetMute getMuteRespBody
+	if err = xml.NewDecoder(res.Body).Decode(&respGetMute); err != nil {
+		return "", fmt.Errorf("GetMuteSoapCall XML Decode error: %w", err)
+	}
+
+	return respGetMute.Body.GetMuteResponse.CurrentMute, nil
+}
+
+// GetVolume returns the volume level for our device.
+func (c *Client) GetVolume(ctx context.Context) (int, error) {
+	xmlbuilder, err := getVolumeSoapBuild()
+	if err != nil {
+		return 0, fmt.Errorf("GetVolumeSoapCall build error: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "POST", c.controlURL, xmlbuilder)
+	if err != nil {
+		return 0, fmt.Errorf("GetVolumeSoapCall POST error: %w", err)
+	}
+
+	req.Header = utils.BuildRequestHeader(`"urn:schemas-upnp-org:service:RenderingControl:1#GetVolume"`)
+
+	res, err := c.Requesthandler.Do(req)
+	if err != nil {
+		return 0, fmt.Errorf("GetVolumeSoapCall Do POST error: %w", err)
+	}
+	defer res.Body.Close()
+
+	var respGetVolume getVolumeRespBody
+	if err = xml.NewDecoder(res.Body).Decode(&respGetVolume); err != nil {
+		return 0, fmt.Errorf("GetVolumeSoapCall XML Decode error: %w", err)
+	}
+
+	intVolume, err := strconv.Atoi(respGetVolume.Body.GetVolumeResponse.CurrentVolume)
+	if err != nil {
+		return 0, fmt.Errorf("GetVolumeSoapCall failed to parse volume value: %w", err)
+	}
+
+	return max(intVolume, 0), nil
+}
+
+// SetMute sets the mute status of the device
+func (c *Client) SetMute(ctx context.Context, muted bool) error {
+	xmlbuilder, err := setMuteSoapBuild(muted)
+	if err != nil {
+		return fmt.Errorf("SetMuteSoapCall build error: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "POST", c.controlURL, xmlbuilder)
+	if err != nil {
+		return fmt.Errorf("SetMuteSoapCall POST error: %w", err)
+	}
+
+	req.Header = utils.BuildRequestHeader(`"urn:schemas-upnp-org:service:RenderingControl:1#SetMute"`)
+
+	res, err := c.Requesthandler.Do(req)
+	if err != nil {
+		return fmt.Errorf("SetMuteSoapCall Do POST error: %w", err)
+	}
+	defer res.Body.Close()
+
+	if _, err := io.ReadAll(res.Body); err != nil {
+		return fmt.Errorf("SetMuteSoapCall Failed to read response: %w", err)
+	}
+
+	return nil
+}
+
+// SetVolume sets the desired volume level.
+func (c *Client) SetVolume(ctx context.Context, vol int) error {
+	v := strconv.Itoa(vol)
+	xmlbuilder, err := setVolumeSoapBuild(v)
+	if err != nil {
+		return fmt.Errorf("SetVolumeSoapCall build error: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "POST", c.controlURL, xmlbuilder)
+	if err != nil {
+		return fmt.Errorf("SetVolumeSoapCall POST error: %w", err)
+	}
+
+	req.Header = utils.BuildRequestHeader(`"urn:schemas-upnp-org:service:RenderingControl:1#SetVolume"`)
+
+	res, err := c.Requesthandler.Do(req)
+	if err != nil {
+		return fmt.Errorf("SetVolumeSoapCall Do POST error: %w", err)
+	}
+	defer res.Body.Close()
+
+	return nil
+}

--- a/third_party/go-upnpcast/services/renderingcontrol/requestbuilders.go
+++ b/third_party/go-upnpcast/services/renderingcontrol/requestbuilders.go
@@ -1,0 +1,165 @@
+package renderingcontrol
+
+import (
+	"encoding/xml"
+	"io"
+
+	"github.com/supersonic-app/go-upnpcast/internal/utils"
+)
+
+type setMuteEnvelope struct {
+	XMLName     xml.Name    `xml:"s:Envelope"`
+	Schema      string      `xml:"xmlns:s,attr"`
+	Encoding    string      `xml:"s:encodingStyle,attr"`
+	SetMuteBody setMuteBody `xml:"s:Body"`
+}
+
+type setMuteBody struct {
+	XMLName       xml.Name      `xml:"s:Body"`
+	SetMuteAction setMuteAction `xml:"u:SetMute"`
+}
+
+type setMuteAction struct {
+	XMLName          xml.Name `xml:"u:SetMute"`
+	RenderingControl string   `xml:"xmlns:u,attr"`
+	InstanceID       string
+	Channel          string
+	DesiredMute      string
+}
+
+type getMuteEnvelope struct {
+	XMLName     xml.Name    `xml:"s:Envelope"`
+	Schema      string      `xml:"xmlns:s,attr"`
+	Encoding    string      `xml:"s:encodingStyle,attr"`
+	GetMuteBody getMuteBody `xml:"s:Body"`
+}
+
+type getMuteBody struct {
+	XMLName       xml.Name      `xml:"s:Body"`
+	GetMuteAction getMuteAction `xml:"u:GetMute"`
+}
+
+type getMuteAction struct {
+	XMLName          xml.Name `xml:"u:GetMute"`
+	RenderingControl string   `xml:"xmlns:u,attr"`
+	InstanceID       string
+	Channel          string
+}
+
+type getVolumeEnvelope struct {
+	XMLName       xml.Name      `xml:"s:Envelope"`
+	Schema        string        `xml:"xmlns:s,attr"`
+	Encoding      string        `xml:"s:encodingStyle,attr"`
+	GetVolumeBody getVolumeBody `xml:"s:Body"`
+}
+
+type getVolumeBody struct {
+	XMLName         xml.Name        `xml:"s:Body"`
+	GetVolumeAction getVolumeAction `xml:"u:GetVolume"`
+}
+
+type getVolumeAction struct {
+	XMLName          xml.Name `xml:"u:GetVolume"`
+	RenderingControl string   `xml:"xmlns:u,attr"`
+	InstanceID       string
+	Channel          string
+}
+
+type setVolumeEnvelope struct {
+	XMLName       xml.Name      `xml:"s:Envelope"`
+	Schema        string        `xml:"xmlns:s,attr"`
+	Encoding      string        `xml:"s:encodingStyle,attr"`
+	SetVolumeBody setVolumeBody `xml:"s:Body"`
+}
+
+type setVolumeBody struct {
+	XMLName         xml.Name        `xml:"s:Body"`
+	SetVolumeAction setVolumeAction `xml:"u:SetVolume"`
+}
+
+type setVolumeAction struct {
+	XMLName          xml.Name `xml:"u:SetVolume"`
+	RenderingControl string   `xml:"xmlns:u,attr"`
+	InstanceID       string
+	Channel          string
+	DesiredVolume    string
+}
+
+func setMuteSoapBuild(muted bool) (io.Reader, error) {
+	m := "0"
+	if muted {
+		m = "1"
+	}
+
+	d := setMuteEnvelope{
+		XMLName:  xml.Name{},
+		Schema:   "http://schemas.xmlsoap.org/soap/envelope/",
+		Encoding: "http://schemas.xmlsoap.org/soap/encoding/",
+		SetMuteBody: setMuteBody{
+			XMLName: xml.Name{},
+			SetMuteAction: setMuteAction{
+				XMLName:          xml.Name{},
+				RenderingControl: "urn:schemas-upnp-org:service:RenderingControl:1",
+				InstanceID:       "0",
+				Channel:          "Master",
+				DesiredMute:      m,
+			},
+		},
+	}
+	return utils.MarshalXMLWithStart(d)
+}
+
+func getMuteSoapBuild() (io.Reader, error) {
+	d := getMuteEnvelope{
+		XMLName:  xml.Name{},
+		Schema:   "http://schemas.xmlsoap.org/soap/envelope/",
+		Encoding: "http://schemas.xmlsoap.org/soap/encoding/",
+		GetMuteBody: getMuteBody{
+			XMLName: xml.Name{},
+			GetMuteAction: getMuteAction{
+				XMLName:          xml.Name{},
+				RenderingControl: "urn:schemas-upnp-org:service:RenderingControl:1",
+				InstanceID:       "0",
+				Channel:          "Master",
+			},
+		},
+	}
+	return utils.MarshalXMLWithStart(d)
+}
+
+func getVolumeSoapBuild() (io.Reader, error) {
+	d := getVolumeEnvelope{
+		XMLName:  xml.Name{},
+		Schema:   "http://schemas.xmlsoap.org/soap/envelope/",
+		Encoding: "http://schemas.xmlsoap.org/soap/encoding/",
+		GetVolumeBody: getVolumeBody{
+			XMLName: xml.Name{},
+			GetVolumeAction: getVolumeAction{
+				XMLName:          xml.Name{},
+				RenderingControl: "urn:schemas-upnp-org:service:RenderingControl:1",
+				InstanceID:       "0",
+				Channel:          "Master",
+			},
+		},
+	}
+	return utils.MarshalXMLWithStart(d)
+}
+
+func setVolumeSoapBuild(v string) (io.Reader, error) {
+	d := setVolumeEnvelope{
+		XMLName:  xml.Name{},
+		Schema:   "http://schemas.xmlsoap.org/soap/envelope/",
+		Encoding: "http://schemas.xmlsoap.org/soap/encoding/",
+		SetVolumeBody: setVolumeBody{
+			XMLName: xml.Name{},
+			SetVolumeAction: setVolumeAction{
+				XMLName:          xml.Name{},
+				RenderingControl: "urn:schemas-upnp-org:service:RenderingControl:1",
+				InstanceID:       "0",
+				Channel:          "Master",
+				DesiredVolume:    v,
+			},
+		},
+	}
+	return utils.MarshalXMLWithStart(d)
+}

--- a/third_party/go-upnpcast/services/renderingcontrol/requestbuilders_test.go
+++ b/third_party/go-upnpcast/services/renderingcontrol/requestbuilders_test.go
@@ -1,0 +1,118 @@
+package renderingcontrol
+
+import (
+	"io"
+	"strings"
+	"testing"
+)
+
+func TestSetMuteSoapBuild(t *testing.T) {
+	tt := []struct {
+		name  string
+		input bool
+		want  string
+	}{
+		{
+			`setMuteSoapBuild Test #1`,
+			true,
+			`<?xml version="1.0" encoding="utf-8"?><s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"><s:Body><u:SetMute xmlns:u="urn:schemas-upnp-org:service:RenderingControl:1"><InstanceID>0</InstanceID><Channel>Master</Channel><DesiredMute>1</DesiredMute></u:SetMute></s:Body></s:Envelope>`,
+		},
+		{
+			`setMuteSoapBuild Test #2`,
+			false,
+			`<?xml version="1.0" encoding="utf-8"?><s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"><s:Body><u:SetMute xmlns:u="urn:schemas-upnp-org:service:RenderingControl:1"><InstanceID>0</InstanceID><Channel>Master</Channel><DesiredMute>0</DesiredMute></u:SetMute></s:Body></s:Envelope>`,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			out, err := setMuteSoapBuild(tc.input)
+			if err != nil {
+				t.Fatalf("%s: Failed to call setMuteSoapBuild due to %s", tc.name, err.Error())
+			}
+			if readerToString(out) != tc.want {
+				t.Fatalf("%s: got: %s, want: %s.", tc.name, out, tc.want)
+			}
+		})
+	}
+}
+
+func TestGetVolumeSoapBuild(t *testing.T) {
+	tt := []struct {
+		name string
+		want string
+	}{
+		{
+			`getVolumeSoapBuild Test #1`,
+			`<?xml version="1.0" encoding="utf-8"?><s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"><s:Body><u:GetVolume xmlns:u="urn:schemas-upnp-org:service:RenderingControl:1"><InstanceID>0</InstanceID><Channel>Master</Channel></u:GetVolume></s:Body></s:Envelope>`,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			out, err := getVolumeSoapBuild()
+			if err != nil {
+				t.Fatalf("%s: Failed to call setMuteSoapBuild due to %s", tc.name, err.Error())
+			}
+			if readerToString(out) != tc.want {
+				t.Fatalf("%s: got: %s, want: %s.", tc.name, out, tc.want)
+			}
+		})
+	}
+}
+
+func TestGetMuteSoapBuild(t *testing.T) {
+	tt := []struct {
+		name string
+		want string
+	}{
+		{
+			`getMuteSoapBuild Test #1`,
+			`<?xml version="1.0" encoding="utf-8"?><s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"><s:Body><u:GetMute xmlns:u="urn:schemas-upnp-org:service:RenderingControl:1"><InstanceID>0</InstanceID><Channel>Master</Channel></u:GetMute></s:Body></s:Envelope>`,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			out, err := getMuteSoapBuild()
+			if err != nil {
+				t.Fatalf("%s: Failed to call getMuteSoapBuild due to %s", tc.name, err.Error())
+			}
+			if readerToString(out) != tc.want {
+				t.Fatalf("%s: got: %s, want: %s.", tc.name, out, tc.want)
+			}
+		})
+	}
+}
+
+func TestSetVolumeSoapBuild(t *testing.T) {
+	tt := []struct {
+		name   string
+		intput string
+		want   string
+	}{
+		{
+			`setVolumeSoapBuild Test #1`,
+			`100`,
+			`<?xml version="1.0" encoding="utf-8"?><s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"><s:Body><u:SetVolume xmlns:u="urn:schemas-upnp-org:service:RenderingControl:1"><InstanceID>0</InstanceID><Channel>Master</Channel><DesiredVolume>100</DesiredVolume></u:SetVolume></s:Body></s:Envelope>`,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			out, err := setVolumeSoapBuild(tc.intput)
+			if err != nil {
+				t.Fatalf("%s: Failed to call setVolumeSoapBuild due to %s", tc.name, err.Error())
+			}
+			if readerToString(out) != tc.want {
+				t.Fatalf("%s: got: %s, want: %s.", tc.name, out, tc.want)
+			}
+		})
+	}
+}
+
+func readerToString(r io.Reader) string {
+	var buf strings.Builder
+	io.Copy(&buf, r)
+	return buf.String()
+}

--- a/third_party/go-upnpcast/services/renderingcontrol/unmarshal.go
+++ b/third_party/go-upnpcast/services/renderingcontrol/unmarshal.go
@@ -1,0 +1,33 @@
+package renderingcontrol
+
+import "encoding/xml"
+
+type getMuteRespBody struct {
+	XMLName       xml.Name `xml:"Envelope"`
+	Text          string   `xml:",chardata"`
+	EncodingStyle string   `xml:"encodingStyle,attr"`
+	S             string   `xml:"s,attr"`
+	Body          struct {
+		Text            string `xml:",chardata"`
+		GetMuteResponse struct {
+			Text        string `xml:",chardata"`
+			U           string `xml:"u,attr"`
+			CurrentMute string `xml:"CurrentMute"`
+		} `xml:"GetMuteResponse"`
+	} `xml:"Body"`
+}
+
+type getVolumeRespBody struct {
+	XMLName       xml.Name `xml:"Envelope"`
+	Text          string   `xml:",chardata"`
+	EncodingStyle string   `xml:"encodingStyle,attr"`
+	S             string   `xml:"s,attr"`
+	Body          struct {
+		Text              string `xml:",chardata"`
+		GetVolumeResponse struct {
+			Text          string `xml:",chardata"`
+			U             string `xml:"u,attr"`
+			CurrentVolume string `xml:"CurrentVolume"`
+		} `xml:"GetVolumeResponse"`
+	} `xml:"Body"`
+}

--- a/third_party/go-upnpcast/services/services.go
+++ b/third_party/go-upnpcast/services/services.go
@@ -1,0 +1,15 @@
+package services
+
+import "net/http"
+
+type Type = string
+
+const (
+	AVTransport       Type = "urn:schemas-upnp-org:service:AVTransport:1"
+	ConnectionManager Type = "urn:schemas-upnp-org:service:ConnectionManager:1"
+	RenderingControl  Type = "urn:schemas-upnp-org:service:RenderingControl:1"
+)
+
+type RequestHandler interface {
+	Do(request *http.Request) (*http.Response, error)
+}

--- a/ui/controller/controller.go
+++ b/ui/controller/controller.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"archive/zip"
+	"context"
 	"errors"
 	"fmt"
 	"image"
@@ -383,6 +384,7 @@ func (c *Controller) ShowSettingsDialog(themeUpdateCallbk func(), themeFiles map
 		fynetooltip.DestroyPopUpToolTipLayer(pop)
 		c.doModalClosed()
 		c.App.SaveConfigFile()
+		go c.App.PlaybackManager.ScanRemotePlayers(context.Background(), true)
 	}
 	c.ClosePopUpOnEscape(pop)
 	c.haveModal = true

--- a/ui/dialogs/settingsdialog.go
+++ b/ui/dialogs/settingsdialog.go
@@ -1,10 +1,13 @@
 package dialogs
 
 import (
+	"context"
 	"errors"
 	"log"
 	"math"
+	"net"
 	"os"
+	"runtime"
 	"slices"
 	"strconv"
 	"strings"
@@ -838,14 +841,171 @@ func (s *SettingsDialog) createAdvancedTab() *container.TabItem {
 	preventScreensaver := widget.NewCheckWithData(lang.L("Prevent screensaver on Now Playing page"),
 		binding.BindBool(&s.config.Application.PreventScreensaverOnNowPlayingPage))
 
-	return container.NewTabItem(lang.L("Advanced"), container.NewVBox(
+	var networkInterfaceSettings fyne.CanvasObject
+	if runtime.GOOS == "linux" {
+		interfaceOptions, recommendedInterfaces := networkInterfaceOptions()
+		if name := s.config.Application.SSDPInterfaceName; name != "" {
+			displayName := interfaceDisplayName(name, recommendedInterfaces)
+			if !slices.Contains(interfaceOptions, displayName) {
+				interfaceOptions = append(interfaceOptions, displayName)
+			}
+		}
+		interfaceSelect := widget.NewSelect(interfaceOptions, func(name string) {
+			s.config.Application.SSDPInterfaceName = strings.TrimSuffix(name, " (recommended)")
+		})
+		interfaceSelect.Selected = interfaceDisplayName(s.config.Application.SSDPInterfaceName, recommendedInterfaces)
+
+		useDefaultInterface := widget.NewCheck(lang.L("Use default network interface selection"), func(checked bool) {
+			s.config.Application.UseDefaultSSDPInterface = checked
+			if checked {
+				interfaceSelect.Disable()
+			} else {
+				interfaceSelect.Enable()
+			}
+		})
+		useDefaultInterface.Checked = s.config.Application.UseDefaultSSDPInterface
+		if useDefaultInterface.Checked {
+			interfaceSelect.Disable()
+		}
+		networkInterfaceSettings = container.NewVBox(
+			useDefaultInterface,
+			container.NewBorder(nil, nil, widget.NewLabel(lang.L("Network interface")), nil, interfaceSelect),
+		)
+	}
+
+	rendererURLs := widget.NewEntry()
+	rendererURLs.SetText(s.config.Application.DLNARendererURLs)
+	rendererURLs.SetPlaceHolder("http://192.0.2.42:49152/description.xml")
+	rendererURLs.OnChanged = func(value string) {
+		s.config.Application.DLNARendererURLs = value
+	}
+
+	var rendererDiscoverySettings fyne.CanvasObject
+	if runtime.GOOS == "linux" {
+		rendererNames := make(map[string]string)
+		rendererSelect := widget.NewSelect(nil, func(name string) {
+			if url := rendererNames[name]; url != "" {
+				rendererURLs.SetText(url)
+			}
+		})
+		searchStatus := widget.NewLabel("")
+		var searchButton *widget.Button
+		searchButton = widget.NewButton(lang.L("Search for renderers"), func() {
+			searchButton.Disable()
+			searchStatus.SetText(lang.L("Searching..."))
+			appCfg := s.config.Application
+			go func() {
+				ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+				defer cancel()
+				renderers, err := backend.DiscoverDLNARenderers(ctx, &appCfg)
+				fyne.Do(func() {
+					defer searchButton.Enable()
+					if err != nil {
+						searchStatus.SetText(err.Error())
+						return
+					}
+					rendererNames = make(map[string]string, len(renderers))
+					names := make([]string, 0, len(renderers))
+					for _, renderer := range renderers {
+						rendererNames[renderer.Name] = renderer.URL
+						names = append(names, renderer.Name)
+					}
+					rendererSelect.Options = names
+					rendererSelect.Selected = ""
+					rendererSelect.Refresh()
+					if len(names) == 0 {
+						searchStatus.SetText(lang.L("No LinkPlay renderers found"))
+					} else {
+						searchStatus.SetText("")
+					}
+				})
+			}()
+		})
+		rendererDiscoverySettings = container.NewVBox(
+			container.NewBorder(nil, nil, widget.NewLabel(lang.L("Discovered renderer")), searchButton, rendererSelect),
+			searchStatus,
+		)
+	}
+
+	helpButton := widget.NewButtonWithIcon(lang.L("Help"), theme.InfoIcon(), func() {
+		help := widget.NewRichTextFromMarkdown(`## DLNA / UPnP renderer settings
+
+Supersonic normally discovers DLNA players automatically using SSDP. Keep **Use default network interface selection** enabled to preserve that behavior.
+
+On Linux, if the player is not found, disable the checkbox and select the network interface that is connected to the same LAN as the player. Active wired and Wi-Fi interfaces are marked **(recommended)**. This interface selector is only available on Linux.
+
+The **Renderer description URL** is an optional manual fallback. It points to the player's UPnP device description, not to an audio file. For example:
+
+~~~
+http://192.0.2.42:49152/description.xml
+~~~
+
+Enter multiple renderer URLs separated by commas. Close this settings dialog after changing the values; Supersonic will rescan the renderers automatically.`)
+		help.Wrapping = fyne.TextWrapWord
+		help.Scroll = fyne.ScrollVerticalOnly
+		help.Resize(fyne.NewSize(560, 400))
+		dlg := dialog.NewCustom(lang.L("DLNA / UPnP help"), lang.L("Close"), help, s.window)
+		dlg.Resize(fyne.NewSize(650, 520))
+		dlg.Show()
+	})
+	dlnaSettings := []fyne.CanvasObject{
+		s.newSectionSeparator(),
+		container.NewBorder(nil, nil, widget.NewLabel(lang.L("DLNA / UPnP")), nil, helpButton),
+	}
+	if networkInterfaceSettings != nil {
+		dlnaSettings = append(dlnaSettings, networkInterfaceSettings)
+	}
+	if rendererDiscoverySettings != nil {
+		dlnaSettings = append(dlnaSettings, rendererDiscoverySettings)
+	}
+	dlnaSettings = append(dlnaSettings,
+		container.NewBorder(nil, nil, widget.NewLabel(lang.L("Renderer description URL")), nil, rendererURLs),
+	)
+	advancedSettings := []fyne.CanvasObject{
 		multi,
 		update,
 		lrclib,
 		osMediaAPIs,
 		preventScreensaver,
 		imgCacheCfg,
-	))
+	}
+	advancedSettings = append(advancedSettings, dlnaSettings...)
+
+	return container.NewTabItem(lang.L("Advanced"), container.NewVBox(advancedSettings...))
+}
+
+func networkInterfaceOptions() ([]string, map[string]bool) {
+	interfaces, err := net.Interfaces()
+	if err != nil {
+		return nil, nil
+	}
+
+	options := make([]string, 0, len(interfaces))
+	recommended := make(map[string]bool)
+	for _, iface := range interfaces {
+		if iface.Flags&net.FlagUp != 0 && iface.Flags&net.FlagMulticast != 0 && iface.Flags&net.FlagBroadcast != 0 && iface.Flags&net.FlagLoopback == 0 {
+			addresses, err := iface.Addrs()
+			if err == nil {
+				for _, address := range addresses {
+					ip, _, err := net.ParseCIDR(address.String())
+					if err == nil && ip.To4() != nil {
+						recommended[iface.Name] = true
+						break
+					}
+				}
+			}
+		}
+		options = append(options, interfaceDisplayName(iface.Name, recommended))
+	}
+	slices.Sort(options)
+	return options, recommended
+}
+
+func interfaceDisplayName(name string, recommended map[string]bool) string {
+	if recommended[name] {
+		return name + " (recommended)"
+	}
+	return name
 }
 
 func (s *SettingsDialog) doChooseTTFFile(window fyne.Window, entry *widget.Entry) {

--- a/ui/dialogs/settingsdialog_test.go
+++ b/ui/dialogs/settingsdialog_test.go
@@ -1,0 +1,13 @@
+package dialogs
+
+import "testing"
+
+func TestInterfaceDisplayName(t *testing.T) {
+	recommended := map[string]bool{"wlan0": true}
+	if got := interfaceDisplayName("wlan0", recommended); got != "wlan0 (recommended)" {
+		t.Fatalf("got %q", got)
+	}
+	if got := interfaceDisplayName("lo", recommended); got != "lo" {
+		t.Fatalf("got %q", got)
+	}
+}


### PR DESCRIPTION
## Summary

This PR improves DLNA renderer discovery on Linux, with the WiiM Pro as the motivating device. It preserves the existing SSDP behavior by default while adding configurable interface selection, a manual UPnP device URL fallback, and an interactive renderer search flow.

## Motivation

The WiiM Pro used for testing did not respond to SSDP M-SEARCH requests, including searches restricted to the active Wi-Fi interface. As a result, Supersonic could not discover the player automatically on Linux. The WiiM did advertise a LinkPlay mDNS service, and its UPnP device description was reachable directly.

Once the renderer was configured manually, playback exposed a second issue: the WiiM could not reach Supersonic's local HTTP media proxy when the host selected the wrong local interface or when the firewall blocked the incoming proxy connection.

The goal of this change is to make this class of renderer usable without removing the normal automatic discovery path.

## What Changed

- Preserve all-interface SSDP discovery as the default behavior for existing configurations.
- Add a Linux Advanced Settings option to select the SSDP network interface explicitly. Active IPv4 multicast/broadcast interfaces are marked as recommended.
- Add an optional, persistent renderer description URL field. Multiple URLs can be entered as a comma-separated list.
- Add a Linux renderer search button that combines:
  - the existing SSDP renderer search; and
  - Avahi/mDNS discovery of `_linkplay._tcp` renderers when available.
- Display discovered renderer names in a selectable UI list; selecting a renderer fills the still-editable URL field.
- Automatically rescan renderers after the settings dialog is closed.
- Use the selected interface's IPv4 address for the local DLNA media proxy when an explicit interface is configured.
- Serialize SSDP searches because `go-ssdp` stores interface selection in package-global state.
- Validate manually configured UPnP device descriptions and required AVTransport/RenderingControl services.
- Propagate non-success HTTP status codes from UPnP/SOAP requests instead of treating them as successful requests.
- Keep the local `go-upnpcast` source in the repository so the patched dependency is reproducible through the existing Go module replacement.

## Platform Behavior

- Linux: explicit interface selection, Avahi LinkPlay discovery, manual URL fallback, and interface-aware proxy binding are available.
- Other platforms: the new Linux-only UI and Avahi path are disabled; the existing default SSDP behavior remains the supported path.

## Testing

The following checks pass on Linux:

```text
go test ./...
go test -race ./backend ./backend/player/dlna ./ui/dialogs
go vet ./...
go build -tags migrated_fynedo
cd third_party/go-upnpcast && go test ./...
cd third_party/go-upnpcast && go vet ./...
```

The added tests cover:

- legacy configuration migration and default SSDP behavior;
- configured renderer URL parsing and fallback;
- selected-interface proxy address handling;
- Avahi LinkPlay output parsing and IPv4 de-duplication;
- DLNA media metadata generation;
- Linux interface recommendation display; and
- UPnP description URL/service validation and SOAP HTTP errors.

The existing project does not currently provide a Fyne dialog or end-to-end UI test suite, so the UI logic is covered through its extracted helper and the backend behavior is tested directly.

## Manual Verification

The change was manually verified against a WiiM Pro on a Linux/Omarchy workstation:

- the renderer was loaded from its UPnP device description;
- AVTransport and RenderingControl requests succeeded;
- playback reached `PLAYING`; and
- the WiiM fetched the media through Supersonic's local HTTP proxy after allowing inbound TCP ports `32768:60999` from the renderer in UFW.

The firewall rule is environment-specific and is not applied by Supersonic.

## Notes

- Avahi discovery is an optional Linux enhancement; manual renderer URLs remain available when `avahi-browse` is not installed.
- No personal IP addresses, hostnames, interface names, MAC addresses, or device UUIDs are included in this branch.